### PR TITLE
Use of statistical imputation ok

### DIFF
--- a/notebooks/.ipynb_checkpoints/Data_preparation-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/Data_preparation-checkpoint.ipynb
@@ -1505,7 +1505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "id": "3d965e2c-60ae-41fe-b4fc-40fd20f28629",
    "metadata": {},
    "outputs": [
@@ -1560,33 +1560,832 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c9358703-7655-42de-a795-22c7cc0767fd",
+   "cell_type": "markdown",
+   "id": "7fc3f854-b862-44d1-97f2-28ba37bd07ae",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "### How to Use Statistical Imputation"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "id": "36894fd9-0b5f-4bc0-9777-caaec7e06eef",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Shape of horse_colic_data : (300, 28)'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Load datasets\n",
+    "\n",
+    "# Load diabetes data\n",
+    "path_horse_colic= \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/horse-colic.csv\"\n",
+    "\n",
+    "horse_colic_data=pd.read_csv(path_horse_colic,header=None)\n",
+    "display(f\"Shape of horse_colic_data : {horse_colic_data.shape}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "id": "4670e8f5-3942-4620-995a-fd318eabec9c",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "# Copy of datasets\n",
+    "horse_colic_data_copy = horse_colic_data.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "6644402f-a0f6-45f5-843e-6557fcbd7720",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "      <th>4</th>\n",
+       "      <th>5</th>\n",
+       "      <th>6</th>\n",
+       "      <th>7</th>\n",
+       "      <th>8</th>\n",
+       "      <th>9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>18</th>\n",
+       "      <th>19</th>\n",
+       "      <th>20</th>\n",
+       "      <th>21</th>\n",
+       "      <th>22</th>\n",
+       "      <th>23</th>\n",
+       "      <th>24</th>\n",
+       "      <th>25</th>\n",
+       "      <th>26</th>\n",
+       "      <th>27</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530101</td>\n",
+       "      <td>38.50</td>\n",
+       "      <td>66</td>\n",
+       "      <td>28</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>?</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>45.00</td>\n",
+       "      <td>8.40</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>11300</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>534817</td>\n",
+       "      <td>39.2</td>\n",
+       "      <td>88</td>\n",
+       "      <td>20</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>50</td>\n",
+       "      <td>85</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2208</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530334</td>\n",
+       "      <td>38.30</td>\n",
+       "      <td>40</td>\n",
+       "      <td>24</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>33.00</td>\n",
+       "      <td>6.70</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "      <td>5290409</td>\n",
+       "      <td>39.10</td>\n",
+       "      <td>164</td>\n",
+       "      <td>84</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>48.00</td>\n",
+       "      <td>7.20</td>\n",
+       "      <td>3</td>\n",
+       "      <td>5.30</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2208</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530255</td>\n",
+       "      <td>37.30</td>\n",
+       "      <td>104</td>\n",
+       "      <td>35</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>74.00</td>\n",
+       "      <td>7.40</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4300</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 28 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  0   1        2      3    4   5  6  7  8  9   ...     18    19 20    21 22  \\\n",
+       "0  2   1   530101  38.50   66  28  3  3  ?  2  ...  45.00  8.40  ?     ?  2   \n",
+       "1  1   1   534817   39.2   88  20  ?  ?  4  1  ...     50    85  2     2  3   \n",
+       "2  2   1   530334  38.30   40  24  1  1  3  1  ...  33.00  6.70  ?     ?  1   \n",
+       "3  1   9  5290409  39.10  164  84  4  1  6  2  ...  48.00  7.20  3  5.30  2   \n",
+       "4  2   1   530255  37.30  104  35  ?  ?  6  2  ...  74.00  7.40  ?     ?  2   \n",
+       "\n",
+       "  23     24 25 26 27  \n",
+       "0  2  11300  0  0  2  \n",
+       "1  2   2208  0  0  2  \n",
+       "2  2      0  0  0  1  \n",
+       "3  1   2208  0  0  1  \n",
+       "4  2   4300  0  0  2  \n",
+       "\n",
+       "[5 rows x 28 columns]"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Head of data\n",
+    "horse_colic_data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "530684f6-5ef2-4404-8521-8bddc80e162d",
+   "metadata": {},
+   "source": [
+    "Marking missing values with a NaN (not a number) value in a loaded dataset using Python is a best practice. \n",
+    "**We can load the dataset using the read csv() Pandas function and specify the na values to load values of “?” as missing, marked with a NaN value.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "c7079f79-aa25-47ec-8066-b808058fe7f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Shape of horse_colic_data : (300, 28)'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# load dataset\n",
+    "horse_colic_data = read_csv(path_horse_colic, header=None, na_values='?')\n",
+    "display(f\"Shape of horse_colic_data : {horse_colic_data.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "5b772d7f-bef8-4673-9ded-69291e2bdd9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copy of datasets\n",
+    "horse_colic_data_copy = horse_colic_data.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "ecb35143-d5e2-4361-b3b7-38b3f871c71d",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "      <th>4</th>\n",
+       "      <th>5</th>\n",
+       "      <th>6</th>\n",
+       "      <th>7</th>\n",
+       "      <th>8</th>\n",
+       "      <th>9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>18</th>\n",
+       "      <th>19</th>\n",
+       "      <th>20</th>\n",
+       "      <th>21</th>\n",
+       "      <th>22</th>\n",
+       "      <th>23</th>\n",
+       "      <th>24</th>\n",
+       "      <th>25</th>\n",
+       "      <th>26</th>\n",
+       "      <th>27</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530101</td>\n",
+       "      <td>38.5</td>\n",
+       "      <td>66.0</td>\n",
+       "      <td>28.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>8.4</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>11300</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>534817</td>\n",
+       "      <td>39.2</td>\n",
+       "      <td>88.0</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>85.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2208</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530334</td>\n",
+       "      <td>38.3</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>24.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>9</td>\n",
+       "      <td>5290409</td>\n",
+       "      <td>39.1</td>\n",
+       "      <td>164.0</td>\n",
+       "      <td>84.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>48.0</td>\n",
+       "      <td>7.2</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.3</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2208</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530255</td>\n",
+       "      <td>37.3</td>\n",
+       "      <td>104.0</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>74.0</td>\n",
+       "      <td>7.4</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4300</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 28 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    0   1        2     3      4     5    6    7    8    9   ...    18    19  \\\n",
+       "0  2.0   1   530101  38.5   66.0  28.0  3.0  3.0  NaN  2.0  ...  45.0   8.4   \n",
+       "1  1.0   1   534817  39.2   88.0  20.0  NaN  NaN  4.0  1.0  ...  50.0  85.0   \n",
+       "2  2.0   1   530334  38.3   40.0  24.0  1.0  1.0  3.0  1.0  ...  33.0   6.7   \n",
+       "3  1.0   9  5290409  39.1  164.0  84.0  4.0  1.0  6.0  2.0  ...  48.0   7.2   \n",
+       "4  2.0   1   530255  37.3  104.0  35.0  NaN  NaN  6.0  2.0  ...  74.0   7.4   \n",
+       "\n",
+       "    20   21   22  23     24  25  26  27  \n",
+       "0  NaN  NaN  2.0   2  11300   0   0   2  \n",
+       "1  2.0  2.0  3.0   2   2208   0   0   2  \n",
+       "2  NaN  NaN  1.0   2      0   0   0   1  \n",
+       "3  3.0  5.3  2.0   1   2208   0   0   1  \n",
+       "4  NaN  NaN  2.0   2   4300   0   0   2  \n",
+       "\n",
+       "[5 rows x 28 columns]"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Head of data\n",
+    "horse_colic_data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "3ff2b6ac-73bc-4165-bf43-a5a924f26a1b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 0, Missing: 6 (2.0%)\n",
+      "> 1, Missing: 5 (1.7%)\n",
+      "> 2, Missing: 5 (1.7%)\n",
+      "> 3, Missing: 1 (0.3%)\n",
+      "> 4, Missing: 12 (4.0%)\n",
+      "> 5, Missing: 8 (2.7%)\n",
+      "> 6, Missing: 3 (1.0%)\n",
+      "> 7, Missing: 8 (2.7%)\n",
+      "> 8, Missing: 4 (1.3%)\n",
+      "> 9, Missing: 4 (1.3%)\n",
+      "> 10, Missing: 0 (0.0%)\n",
+      "> 11, Missing: 4 (1.3%)\n",
+      "> 12, Missing: 4 (1.3%)\n",
+      "> 13, Missing: 2 (0.7%)\n",
+      "> 14, Missing: 1 (0.3%)\n",
+      "> 15, Missing: 3 (1.0%)\n",
+      "> 16, Missing: 3 (1.0%)\n",
+      "> 17, Missing: 16 (5.3%)\n",
+      "> 18, Missing: 2 (0.7%)\n",
+      "> 19, Missing: 9 (3.0%)\n",
+      "> 20, Missing: 2 (0.7%)\n",
+      "> 21, Missing: 3 (1.0%)\n",
+      "> 22, Missing: 7 (2.3%)\n",
+      "> 23, Missing: 10 (3.3%)\n",
+      "> 24, Missing: 5 (1.7%)\n",
+      "> 25, Missing: 15 (5.0%)\n",
+      "> 26, Missing: 1 (0.3%)\n",
+      "> 27, Missing: 2 (0.7%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# summarize the number of rows with missing values for each column \n",
+    "for i in range(horse_colic_data.shape[1]):\n",
+    "    # count number of rows with missing values \n",
+    "    n_miss = horse_colic_data.iloc[i].isnull().sum()\n",
+    "    perc = n_miss / horse_colic_data.shape[0] * 100\n",
+    "    perc = round(perc,1)\n",
+    "    print(f'> {i}, Missing: {n_miss} ({perc}%)' )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3d2e73e-1df5-475d-81dc-ed99e2de2ec2",
+   "metadata": {},
+   "source": [
+    "#### Statistical Imputation With SimpleImputer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e65e0ab-30ae-4ad5-8f26-ea4b2290c12b",
+   "metadata": {},
+   "source": [
+    "The scikit-learn machine learning library provides the SimpleImputer class that supports statistical imputation. In this section, we will explore how to effectively use the SimpleImputer class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "78d91352-22f4-420b-b2ce-1dc1825a65ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Missing:  1605\n",
+      "Missing:  0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# statistical imputation transform for the horse colic dataset from numpy import isnan\n",
+    "from pandas import read_csv\n",
+    "from sklearn.impute import SimpleImputer\n",
+    "\n",
+    "# load dataset\n",
+    "horse_colic_data = horse_colic_data_copy\n",
+    "\n",
+    "# split into input and output elements\n",
+    "data = horse_colic_data.values\n",
+    "ix = [i for i in range(data.shape[1]) if i != 23] \n",
+    "X, y = data[:, ix], data[:, 23]\n",
+    "\n",
+    "# summarize total missing\n",
+    "print(f\"Missing:  {sum(np.isnan(X).flatten())}\") \n",
+    "\n",
+    "# define imputer\n",
+    "imputer = SimpleImputer(strategy='mean') \n",
+    "\n",
+    "# fit on the dataset\n",
+    "imputer.fit(X)\n",
+    "\n",
+    "# transform the dataset \n",
+    "Xtrans = imputer.transform(X) \n",
+    "\n",
+    "# summarize total missing\n",
+    "print(f\"Missing:  {sum(np.isnan(Xtrans).flatten())}\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7d96484-7dfe-4b7b-a1c0-5fde2227b745",
+   "metadata": {},
+   "source": [
+    "#### SimpleImputer and Model Evaluation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54ad368b-e34d-49db-bf6f-ebff617bbd47",
+   "metadata": {},
+   "source": [
+    "It is a good practice to evaluate machine learning models on a dataset using k-fold cross- validation. **To correctly apply statistical missing data imputation and avoid data leakage**, it is required that the statistics calculated for each column are calculated on the training dataset only, then applied to the train and test sets for each fold in the dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be3f39e3-cab8-4e77-a42f-fc4ab25e2406",
+   "metadata": {},
+   "source": [
+    "This can be achieved by creating a modeling pipeline where the first step is the statistical imputation, then the second step is the model. This can be achieved using the Pipeline class. For example, the Pipeline below uses a SimpleImputer with a ‘mean’ strategy, followed by a random forest model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "0d49e1ba-b2f9-4335-8ebd-1d180d6c3b5b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mean Accuracy: 0.857 (0.052)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# evaluate mean imputation and random forest for the horse colic dataset from numpy import mean\n",
+    "from numpy import std\n",
+    "from pandas import read_csv\n",
+    "from sklearn.ensemble import RandomForestClassifier \n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "from sklearn.model_selection import RepeatedStratifiedKFold \n",
+    "from sklearn.pipeline import Pipeline\n",
+    "\n",
+    "# load dataset\n",
+    "horse_colic_data = horse_colic_data_copy\n",
+    "\n",
+    "# split into input and output elements\n",
+    "data = horse_colic_data.values\n",
+    "ix = [i for i in range(data.shape[1]) if i != 23] \n",
+    "X, y = data[:, ix], data[:, 23]\n",
+    "\n",
+    "# define modeling pipeline\n",
+    "model = RandomForestClassifier()\n",
+    "imputer = SimpleImputer(strategy='mean')\n",
+    "pipeline = Pipeline(steps=[('i', imputer), ('m', model)]) \n",
+    "\n",
+    "# define model evaluation\n",
+    "cv = RepeatedStratifiedKFold(n_splits=10, n_repeats=3, random_state=1) \n",
+    "\n",
+    "# evaluate model\n",
+    "scores = cross_val_score(pipeline, X, y, scoring='accuracy', cv=cv, n_jobs=-1) \n",
+    "print(f'Mean Accuracy: {round(mean(scores),3)} ({round(std(scores),3)})')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5ef1573-c9c9-489c-a16e-cb4336013bb4",
+   "metadata": {},
+   "source": [
+    "#### Comparing Different Imputed Statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "daf39d4d-fdb0-4703-8302-428d1abb4145",
+   "metadata": {},
+   "source": [
+    "How do we know that using a ‘mean’ statistical strategy is good or best for this dataset? The answer is that we don’t and that it was chosen arbitrarily. We can design an experiment to test each statistical strategy and discover what works best for this dataset, comparing the mean, median, mode (most frequent), and constant (0) strategies. The mean accuracy of each approach can then be compared. The complete example is listed below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "0cc8d6e2-a1f4-48e1-b5b0-eb6ba13cf6d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">mean 0.867 (0.054)\n",
+      ">median 0.873 (0.057)\n",
+      ">most_frequent 0.866 (0.062)\n",
+      ">constant 0.876 (0.047)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGdCAYAAAAxCSikAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAMutJREFUeJzt3X9c1fXB//8nHOOXgGYioDlRUKFETVr4I6desTDLS/Kyy2mWcSUrm7u20S81E80lVyvJ5sVmudSlV2lTZt85Z22Uy5TUgVtRoPiDaQn+agooinJenz/6euwomgeF8wIe99vt3PS8369fb15wePJ6v8/7+BhjjAAAACzm6+0BAAAAfBsCCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAeq28PYBrwel06sCBAwoJCZGPj4+3hwMAAK6AMUaVlZXq2LGjfH0vv4bSLALLgQMH1LlzZ28PAwAA1MP+/ft14403XrZMswgsISEhkr4+4NDQUC+PBgAAXImKigp17tzZ9Xv8cppFYDl3Gig0NJTAAgBAE3Mll3Nw0S0AALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYL1mceM4AACaqtraWm3cuFFlZWWKjIzU4MGD5XA4vD0s67DCAgCAl+Tk5CgmJkbDhg3T+PHjNWzYMMXExCgnJ8fbQ7MOgQUAAC/IycnRmDFjFB8fr7y8PFVWViovL0/x8fEaM2YMoeUCPsYY4+1BXK2Kigq1adNGx48f57OEAADWq62tVUxMjOLj47VmzRr5+p5fP3A6nUpJSVFhYaFKSkqa9ekhT35/cw2LJU6ePKni4mKP6lRXV6u0tFRRUVEKDAz0uM/Y2FgFBQV5XA9Xj/luWZhvXGjjxo0qLS3VW2+95RZWJMnX11fTpk3TwIEDtXHjRg0dOtQ7g7QMgcUSxcXFSkhIaNQ+8/Pz1a9fv0btE19jvlsW5hsXKisrkyT16tWrzv3ntp8rBwKLNWJjY5Wfn+9RnaKiIk2YMEHLly9XXFxcvfqEdzDfLQvzjQtFRkZKkgoLC9W/f/+L9hcWFrqVA4HFGkFBQfX+ayguLo6/pJoY5rtlYb5xocGDBysqKkpz586t8xqWzMxMde3aVYMHD/biKO3Cu4QAAGhkDodD8+bN09q1a5WSkuL2LqGUlBStXbtWL730UrO+4NZTrLAAAOAFo0eP1qpVq/T4449r4MCBru1du3bVqlWrNHr0aC+Ozj4EFgAAvGT06NEaNWoUd7q9AgQWAAC8yOFw8NblK8A1LAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsV6/Akp2draioKAUEBCgxMVFbt269ZNkzZ87oueeeU3R0tAICAtSnTx+tX7/ercysWbPk4+Pj9oiNja3P0AAAQDPkcWBZuXKl0tPTlZGRoYKCAvXp00fJyck6dOhQneVnzJihV199VQsWLNDnn3+uRx99VPfee6+2b9/uVu7mm29WWVmZ6/HRRx/V74gAAECz43FgycrKUlpamlJTU3XTTTdp4cKFCgoK0uLFi+ssv2zZMk2fPl0jRoxQt27dNHnyZI0YMULz5s1zK9eqVStFRES4Hu3bt6/fEQEAgGbHo8BSU1Oj/Px8JSUlnW/A11dJSUnKy8urs87p06cVEBDgti0wMPCiFZSSkhJ17NhR3bp10/333699+/ZdchynT59WRUWF2wMAADRfHgWWI0eOqLa2VuHh4W7bw8PDVV5eXmed5ORkZWVlqaSkRE6nU3/+85+Vk5OjsrIyV5nExEQtXbpU69ev169//Wvt3btXgwcPVmVlZZ1tZmZmqk2bNq5H586dPTkMAADQxDT4u4ReeeUVde/eXbGxsfLz89OUKVOUmpoqX9/zXd91112677771Lt3byUnJ2vdunU6duyY3n777TrbnDZtmo4fP+567N+/v6EPAwAAeJFHgaV9+/ZyOBw6ePCg2/aDBw8qIiKizjphYWFas2aNTpw4oX/+858qLi5WcHCwunXrdsl+2rZtqx49emjXrl117vf391doaKjbAwAANF8eBRY/Pz8lJCQoNzfXtc3pdCo3N1cDBgy4bN2AgAB16tRJZ8+e1erVqzVq1KhLlq2qqtLu3bsVGRnpyfAAAEAz5fEpofT0dC1atEi//e1vVVRUpMmTJ+vEiRNKTU2VJD344IOaNm2aq/yWLVuUk5OjPXv2aOPGjRo+fLicTqeeeuopV5knnnhCf/3rX1VaWqrNmzfr3nvvlcPh0Lhx467BIQIAgKaulacVxo4dq8OHD2vmzJkqLy9X3759tX79eteFuPv27XO7PuXUqVOaMWOG9uzZo+DgYI0YMULLli1T27ZtXWW++OILjRs3TkePHlVYWJhuv/12ffzxxwoLC7v6IwQAAE2ex4FFkqZMmaIpU6bUuW/Dhg1uz4cMGaLPP//8su2tWLGiPsMAAAAtBJ8lBAAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFivlbcHAABAc3Ly5EkVFxd7VKe6ulqlpaWKiopSYGCgx33GxsYqKCjI43pNCYEFAIBrqLi4WAkJCY3aZ35+vvr169eofTY2AgsAANdQbGys8vPzPapTVFSkCRMmaPny5YqLi6tXn80dgQUAgGsoKCio3qsdcXFxzX6lpL646BYAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYr16BJTs7W1FRUQoICFBiYqK2bt16ybJnzpzRc889p+joaAUEBKhPnz5av379VbUJAABaFo8Dy8qVK5Wenq6MjAwVFBSoT58+Sk5O1qFDh+osP2PGDL366qtasGCBPv/8cz366KO69957tX379nq3CQAAWhaPA0tWVpbS0tKUmpqqm266SQsXLlRQUJAWL15cZ/lly5Zp+vTpGjFihLp166bJkydrxIgRmjdvXr3bBAAALUsrTwrX1NQoPz9f06ZNc23z9fVVUlKS8vLy6qxz+vRpBQQEuG0LDAzURx99dFVtnj592vW8oqLCk8NocCUlJaqsrGzwfoqKitz+bQwhISHq3r17o/XXFOz5JE+nj/yzwfsp37tXt0T4qnz7uyo6trPB+5Mk//Zd1K33gEbpq6ng57tlYb7t4VFgOXLkiGpraxUeHu62PTw8XMXFxXXWSU5OVlZWlr73ve8pOjpaubm5ysnJUW1tbb3bzMzM1OzZsz0ZeqMpKSlRjx49GrXPCRMmNGp/O3fubFLf5A2ppKRE//ffwzRrqH+D9xUnacQjwdL+/5H2N3h3kqRZG07r/kWfMt//P36+Wxbm2y4eBZb6eOWVV5SWlqbY2Fj5+PgoOjpaqampV3W6Z9q0aUpPT3c9r6ioUOfOna/FcK/auSS+fPlyxcXFNWhf1dXVKi0tVVRUlAIDAxu0L+nr5D9hwoRG+WujqaisrNSr+TW67YEMde3atUH7On36tA4cOKCOHTvK37/hA9LevXv1av4z+nfm24Wf75aF+baLR4Glffv2cjgcOnjwoNv2gwcPKiIios46YWFhWrNmjU6dOqWjR4+qY8eOmjp1qrp161bvNv39/RvlBftqxMXFqV+/fg3ez6BBgxq8D1xeeZVRxC3JimuE+e7b4D2cV11QoPKq6Y3YY9PBz3fLwnzbwaOLbv38/JSQkKDc3FzXNqfTqdzcXA0YcPnz3AEBAerUqZPOnj2r1atXa9SoUVfdJgAAaBk8PiWUnp6uiRMn6tZbb9Vtt92m+fPn68SJE0pNTZUkPfjgg+rUqZMyMzMlSVu2bNGXX36pvn376ssvv9SsWbPkdDr11FNPXXGbAACgZfM4sIwdO1aHDx/WzJkzVV5err59+2r9+vWui2b37dsnX9/zCzenTp3SjBkztGfPHgUHB2vEiBFatmyZ2rZte8VtAgCAlq1eF91OmTJFU6ZMqXPfhg0b3J4PGTJEn3/++VW1CQAAWjY+SwgAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwXitvDwAAmpKIYB8FHtspHWhef+8FHtupiGAfbw8DuCQCCwB44JEEP8V9+Ij0obdHcm3F6etjA2xFYAEAD7yaX6OxM5cqLjbW20O5poqKi/XqvPH6d28PBLgEAgsAeKC8yqi6bQ+pY19vD+Waqi53qrzKeHsYwCU1r5OwAACgWSKwAAAA6xFYAACA9QgsAADAegQWAABgPQILAABelncgT6PWjFLegTxvD8VaBBYAALzIGKNXCl7RnuN79ErBKzKGt5fXhcACAIAXbT6wWZ8d/UyS9NnRz7T5wGYvj8hOBBagiWDJGGh+jDFasH2BfH2+/nXs6+OrBdsXsMpSBwIL0ASwZAw0T+dWV5zGKUlyGierLJdAYAGaAJaMgebnwtWVc1hlqRuBBbAcS8ZA83Th6so5rLLUjcACWI4lY6D5OfeHiI986tzvIx/+MLkAgQWwGEvGQPN0xnlG5SfKZVT3z7CRUfmJcp1xnmnkkdmrlbcHAODSvnntyjd9c5VlUKdBXhgZgKvh5/DTintW6KtTX12yTLuAdvJz+DXiqOxGYAEs9c0l47r+Cju3ZDyw40D5+NS9rAzAXhGtIxTROsLbw2gyOCUEWIolYwA4jxWWJizvQJ7+Z+v/aOptUzWg4wBvDwfXGEvGAHAegaWJuvBGYv0j+3NaoBliyRgAvsYpoSaKG4kBzRsfxQC4Y4WlAUQE+yjw2E7pQMPkQWOMFmx9Qb7ylVNO+cpXC7a+oIG3zW7QVZbAYzsVEcwqDtDQWEG1w8mTJxUR7KN/fvz/ff2a3oBOnz6tAwcOqGPHjvL392/QviSpfO/eJvd6TmBpAI8k+Cnuw0ekDxum/c2BAfosooPruVNOfVaxV5uXD9eg6lMN06mkOH19bAAaVl0rqLx9vfEVFxfrkQQ/3XvoZelQw/fXV5L2N3w/0vnX85CQkMbp8BogsDSAV/NrNHbmUsXFxl7ztr9eXcmQb8U/5dT52zn7ylcLeiQ26CpLUXGxXp03Xv/eIK0DkNxvFug0TtdNAnn7euNLSUnRu7UV2t65nQICAhq0r71792rGjBn6+c9/rq5duzZoX+c8OLqLunXv3ih9XQsElgZQXmVU3baH1LHvNW9785eb9FnF3ou2u1ZZdFKDOjbMX2LV5U6VV3FnVaAhXXizQG4S6D3t27fX/Y+kN0pf1QUF2l4+XRG3JCuuX79G6bOp4aLbJoTPngCaNz6KAbg0AksTwo3EgOaNT+8FLo1TQk0INxIDmi8+igG4PAJLE8ONxIDmyZMVVP4oQUtEYAEAC7CCClwegQUALMEKKnBpXHQLAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOvVK7BkZ2crKipKAQEBSkxM1NatWy9bfv78+erZs6cCAwPVuXNn/exnP9OpU6dc+2fNmiUfHx+3R2xsbH2GBgAAmiGPP/xw5cqVSk9P18KFC5WYmKj58+crOTlZO3bsUIcOHS4q/+abb2rq1KlavHixBg4cqJ07d+qhhx6Sj4+PsrKyXOVuvvlm/eUvfzk/sFZ8LiMAAPiaxyssWVlZSktLU2pqqm666SYtXLhQQUFBWrx4cZ3lN2/erEGDBmn8+PGKiorSnXfeqXHjxl20KtOqVStFRES4Hu3bt6/fEQEAgGbHo8BSU1Oj/Px8JSUlnW/A11dJSUnKy8urs87AgQOVn5/vCih79uzRunXrNGLECLdyJSUl6tixo7p166b7779f+/btu+Q4Tp8+rYqKCrcHAABovjw673LkyBHV1tYqPDzcbXt4eLiKi4vrrDN+/HgdOXJEt99+u4wxOnv2rB599FFNnz7dVSYxMVFLly5Vz549VVZWptmzZ2vw4MEqLCxUSEjIRW1mZmZq9uzZngwdAAA0YQ3+LqENGzZo7ty5+tWvfqWCggLl5OToj3/8o+bMmeMqc9ddd+m+++5T7969lZycrHXr1unYsWN6++2362xz2rRpOn78uOuxf//+hj4MAADgRR6tsLRv314Oh0MHDx50237w4EFFRETUWefZZ5/VAw88oEmTJkmS4uPjdeLECf3whz/UM888I1/fizNT27Zt1aNHD+3atavONv39/eXv7+/J0AEAQBPm0QqLn5+fEhISlJub69rmdDqVm5urAQMG1Fnn5MmTF4USh8MhSTLG1FmnqqpKu3fvVmRkpCfDAwAAzZTH7x1OT0/XxIkTdeutt+q2227T/PnzdeLECaWmpkqSHnzwQXXq1EmZmZmSpJEjRyorK0u33HKLEhMTtWvXLj377LMaOXKkK7g88cQTGjlypLp06aIDBw4oIyNDDodD48aNu4aHCgAAmiqPA8vYsWN1+PBhzZw5U+Xl5erbt6/Wr1/vuhB33759bisqM2bMkI+Pj2bMmKEvv/xSYWFhGjlypJ5//nlXmS+++ELjxo3T0aNHFRYWpttvv10ff/yxwsLCrsEhAgCApq5ed2ebMmWKpkyZUue+DRs2uHfQqpUyMjKUkZFxyfZWrFhRn2EAAIAWgs8SAgAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKzXytsDaG5OnjwpSSooKGjwvqqrq1VaWqqoqCgFBgY2eH9FRUUN3gcANHUnT55UcXGxR3XOvb7W93U2NjZWQUFB9arbVBBYrrFz36RpaWleHknDCQkJ8fYQAMBaxcXFSkhIqFfdCRMm1Ktefn6++vXrV6+6TQWB5RpLSUmR1Dhpt6ioSBMmTNDy5csVFxfXoH2dExISou7duzdKXwDQFMXGxio/P9+jOle7Yh4bG+txnaaGwHKNtW/fXpMmTWrUPuPi4pp9sgaApiIoKKher8mDBg1qgNE0H1x0CwAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYr5W3BwA0ZSdPnpQkFRQUNHhf1dXVKi0tVVRUlAIDAxu8v6Kiogbvo6lhvgHvIbAAV6G4uFiSlJaW5uWRNJyQkBBvD8EazDfgPQQW4CqkpKRIkmJjYxUUFNSgfRUVFWnChAlavny54uLiGrSvc0JCQtS9e/dG6aspYL4B7yGwAFehffv2mjRpUqP2GRcXp379+jVqn/ga8w14DxfdAgAA6xFYAACA9QgsAADAegQWAABgPQILAABeVF1drSlTpig5OVlTpkxRdXW1t4dkpXoFluzsbEVFRSkgIECJiYnaunXrZcvPnz9fPXv2VGBgoDp37qyf/exnOnXq1FW1CQBAU5eSkqKgoCBlZ2frvffeU3Z2toKCglxvocd5HgeWlStXKj09XRkZGSooKFCfPn2UnJysQ4cO1Vn+zTff1NSpU5WRkaGioiK9/vrrWrlypaZPn17vNgEAaOpSUlL0zjvvyM/PT1OnTtWuXbs0depU+fn56Z133iG0XMDjwJKVlaW0tDSlpqbqpptu0sKFCxUUFKTFixfXWX7z5s0aNGiQxo8fr6ioKN15550aN26c2wqKp20CANCUVVdXu8JKZWWlMjMzFR0drczMTFVWVrpCC6eHzvMosNTU1Cg/P19JSUnnG/D1VVJSkvLy8uqsM3DgQOXn57sCyp49e7Ru3TqNGDGi3m2ePn1aFRUVbg8AAJqKJ598UpKUnp4uPz8/t31+fn766U9/6lYOHgaWI0eOqLa2VuHh4W7bw8PDVV5eXmed8ePH67nnntPtt9+u6667TtHR0Ro6dKjrlFB92szMzFSbNm1cj86dO3tyGAAAeFVJSYkkXfLOyQ8//LBbOTTCu4Q2bNiguXPn6le/+pUKCgqUk5OjP/7xj5ozZ06925w2bZqOHz/ueuzfv/8ajhgAgIZ17jObfvOb39S5//XXX3crBw8DS/v27eVwOHTw4EG37QcPHlRERESddZ599lk98MADmjRpkuLj43Xvvfdq7ty5yszMlNPprFeb/v7+Cg0NdXsAANBUvPjii5K+voazpqbGbV9NTY3mz5/vVg4eBhY/Pz8lJCQoNzfXtc3pdCo3N1cDBgyos87Jkyfl6+vejcPhkCQZY+rVJgAATVlgYKBGjRqlmpoahYSE6Omnn9bOnTv19NNPKyQkRDU1NRo1apQCAwO9PVRrePxpzenp6Zo4caJuvfVW3XbbbZo/f75OnDih1NRUSdKDDz6oTp06KTMzU5I0cuRIZWVl6ZZbblFiYqJ27dqlZ599ViNHjnQFl29rEwCA5mbNmjWutzb/4he/0C9+8QvXvlGjRmnNmjXeG5yFPA4sY8eO1eHDhzVz5kyVl5erb9++Wr9+veui2X379rmtqMyYMUM+Pj6aMWOGvvzyS4WFhWnkyJF6/vnnr7hNAACaozVr1qi6ulpPPvmkSkpK1L17d7344ousrNTBxxhjvD2Iq1VRUaE2bdro+PHjLep6loKCAiUkJCg/P1/9+vXz9nDQwJjvloX5Rkvgye9vPksIAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOu18vYAAABoyWpra7Vx40aVlZUpMjJSgwcPlsPh8PawrMMKCwAAXpKTk6OYmBgNGzZM48eP17BhwxQTE6OcnBxvD806BBYAALwgJydHY8aMUXx8vPLy8lRZWam8vDzFx8drzJgxhJYLEFgAAGhktbW1evzxx3XPPfdozZo16t+/v4KDg9W/f3+tWbNG99xzj5544gnV1tZ6e6jW4BoWS5w8eVLFxcUe1SkqKnL711OxsbEKCgqqV11cHeYbaNk2btyo0tJSvfXWW/L1dV878PX11bRp0zRw4EBt3LhRQ4cO9c4gLUNgsURxcbESEhLqVXfChAn1qpefn69+/frVqy6uDvMNtGxlZWWSpF69etW5/9z2c+VAYLFGbGys8vPzPapTXV2t0tJSRUVFKTAwsF59wjuYb6Bli4yMlCQVFhaqf//+F+0vLCx0KwfJxxhjvD2Iq1VRUaE2bdro+PHjCg0N9fZwAOCqFRQUKCEhgZWxZqq2tlYxMTGKj4/XmjVr3E4LOZ1OpaSkqLCwUCUlJc36Lc6e/P7molsAABqZw+HQvHnztHbtWqWkpLi9SyglJUVr167VSy+91KzDiqc4JQQAgBeMHj1aq1at0uOPP66BAwe6tnft2lWrVq3S6NGjvTg6+xBYAADwktGjR2vUqFHc6fYKEFgAAPAih8PBW5evANewAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALBevQJLdna2oqKiFBAQoMTERG3duvWSZYcOHSofH5+LHnfffberzEMPPXTR/uHDh9dnaAAAoBlq5WmFlStXKj09XQsXLlRiYqLmz5+v5ORk7dixQx06dLiofE5OjmpqalzPjx49qj59+ui+++5zKzd8+HAtWbLE9dzf39/ToQEAgGbK4xWWrKwspaWlKTU1VTfddJMWLlyooKAgLV68uM7y7dq1U0REhOvx5z//WUFBQRcFFn9/f7dy119/ff2OCAAANDseBZaamhrl5+crKSnpfAO+vkpKSlJeXt4VtfH666/rBz/4gVq3bu22fcOGDerQoYN69uypyZMn6+jRo5ds4/Tp06qoqHB7AACA5sujwHLkyBHV1tYqPDzcbXt4eLjKy8u/tf7WrVtVWFioSZMmuW0fPny43njjDeXm5uqFF17QX//6V911112qra2ts53MzEy1adPG9ejcubMnhwEAAJoYj69huRqvv/664uPjddttt7lt/8EPfuD6f3x8vHr37q3o6Ght2LBBd9xxx0XtTJs2Tenp6a7nFRUVhBYAAJoxj1ZY2rdvL4fDoYMHD7ptP3jwoCIiIi5b98SJE1qxYoUefvjhb+2nW7duat++vXbt2lXnfn9/f4WGhro9AABA8+VRYPHz81NCQoJyc3Nd25xOp3JzczVgwIDL1v3d736n06dPa8KECd/azxdffKGjR48qMjLSk+EBAIBmyuN3CaWnp2vRokX67W9/q6KiIk2ePFknTpxQamqqJOnBBx/UtGnTLqr3+uuvKyUlRTfccIPb9qqqKj355JP6+OOPVVpaqtzcXI0aNUoxMTFKTk6u52EBAIDmxONrWMaOHavDhw9r5syZKi8vV9++fbV+/XrXhbj79u2Tr697DtqxY4c++ugjvffeexe153A49Mknn+i3v/2tjh07po4dO+rOO+/UnDlzuBcLAACQJPkYY4y3B3G1Kioq1KZNGx0/fpzrWQA0CwUFBUpISFB+fr769evn7eEADcKT3998lhAAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1vP405phh9raWm3cuFFlZWWKjIzU4MGD5XA4vD0sAAAaBCssTVBOTo5iYmI0bNgwjR8/XsOGDVNMTIxycnK8PTQAABoEgaWJycnJ0ZgxYxQfH6+8vDxVVlYqLy9P8fHxGjNmDKEFANAs+RhjjLcHcbUqKirUpk0bHT9+XKGhod4eToOpra1VTEyM4uPjtWbNGvn6ns+bTqdTKSkpKiwsVElJCaeHgCauoKBACQkJys/PV79+/bw9HKBBePL7m2tYmpCNGzeqtLRUb731lltYkSRfX19NmzZNAwcO1MaNGzV06FDvDBLARU6ePKni4mKP6hQVFbn966nY2FgFBQXVqy5gIwJLE1JWViZJ6tWrV537z20/Vw6AHYqLi5WQkFCvuhMmTKhXPVZm0NwQWJqQyMhISVJhYaH69+9/0f7CwkK3cgDsEBsbq/z8fI/qVFdXq7S0VFFRUQoMDKxXn0BzwjUsTQjXsAAAmhNPfn/zLqEmxOFwaN68eVq7dq1SUlLc3iWUkpKitWvX6qWXXiKsAACaHU4JNTGjR4/WqlWr9Pjjj2vgwIGu7V27dtWqVas0evRoL44OAICGwSmhJoo73QIAmjre1twCOBwO3roMAGgxuIYFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFivWdzp9tynC1RUVHh5JAAA4Eqd+719JZ8S1CwCS2VlpSSpc+fOXh4JAADwVGVlpdq0aXPZMs3iww+dTqcOHDigkJAQ+fj4eHs4jaaiokKdO3fW/v37W8yHPrZkzHfLwny3LC11vo0xqqysVMeOHeXre/mrVJrFCouvr69uvPFGbw/Da0JDQ1vUN3hLx3y3LMx3y9IS5/vbVlbO4aJbAABgPQILAACwHoGlCfP391dGRob8/f29PRQ0Aua7ZWG+Wxbm+9s1i4tuAQBA88YKCwAAsB6BBQAAWI/AAgAArEdgAZqgoUOH6qc//anreVRUlObPn++18aB+iouL1b9/fwUEBKhv377eHg5gNQIL0Axs27ZNP/zhD709jBbtoYceUkpKikd1MjIy1Lp1a+3YsUO5ubkNM7BGtmHDBvn4+OjYsWPeHkqTduEfJddSU/0Dp1nc6RZo6cLCwrw9BNTD7t27dffdd6tLly6XLHPmzBldd911jTgqwFIGXjFkyBAzZcoU85Of/MS0bdvWdOjQwbz22mumqqrKPPTQQyY4ONhER0ebdevWuep8+umnZvjw4aZ169amQ4cOZsKECebw4cOu/X/605/MoEGDTJs2bUy7du3M3XffbXbt2uXav3fvXiPJrF692gwdOtQEBgaa3r17m82bNzfqsTdnDTGvVVVV5oEHHjCtW7c2ERER5qWXXjJDhgwxP/nJT1xlunTpYl5++WXX83nz5plevXqZoKAgc+ONN5rJkyebyspK1/4lS5aYNm3amPXr15vY2FjTunVrk5ycbA4cONCgX5/GVJ+52LBhg/nud79r/Pz8TEREhHn66afNmTNnXPt/97vfmV69epmAgADTrl07c8cdd5iqqiqTkZFhJLk9Pvjgg8uO78LyGRkZrp/RFStWmO9973vG39/fLFmyxBhjzKJFi0xsbKzx9/c3PXv2NNnZ2W7tbdmyxfTt29f4+/ubhIQEk5OTYySZ7du3G2POz/k3/f73vzcX/hpYs2aNueWWW4y/v7/p2rWrmTVrltvXQJJZtGiRSUlJMYGBgSYmJsa88847xpjzrzHffEycOPEKZstOtbW15oUXXjDR0dHGz8/PdO7c2fz85z83xhjzySefmGHDhrm+F9LS0tx+xiZOnGhGjRplXnzxRRMREWHatWtnHnvsMVNTU+Mqk52dbWJiYoy/v7/p0KGD+Y//+A9X3Qu/jnv37jVnz541//Vf/2WioqJMQECA6dGjh5k/f77bmL+t3yFDhlzUdlPRdEbazAwZMsSEhISYOXPmmJ07d5o5c+YYh8Nh7rrrLvPaa6+ZnTt3msmTJ5sbbrjBnDhxwvzrX/8yYWFhZtq0aaaoqMgUFBSY73//+2bYsGGuNletWmVWr15tSkpKzPbt283IkSNNfHy8qa2tNcacfzGJjY01a9euNTt27DBjxowxXbp0cXtBQv01xLxOnjzZfOc73zF/+ctfzCeffGLuueceExISctnA8vLLL5v333/f7N271+Tm5pqePXuayZMnu/YvWbLEXHfddSYpKcls27bN5Ofnm7i4ODN+/PjG+DI1Ck/n4osvvjBBQUHmscceM0VFReb3v/+9ad++vcnIyDDGGHPgwAHTqlUrk5WVZfbu3Ws++eQTk52dbSorK01lZaX5z//8TzN8+HBTVlZmysrKzOnTpy87vrKyMnPzzTebxx9/3JSVlZnKykrXz2hUVJRZvXq12bNnjzlw4IBZvny5iYyMdG1bvXq1adeunVm6dKkxxpjKykoTFhZmxo8fbwoLC80f/vAH061bN48Dy4cffmhCQ0PN0qVLze7du817771noqKizKxZs1xlJJkbb7zRvPnmm6akpMT893//twkODjZHjx41Z8+eNatXrzaSzI4dO0xZWZk5duzY1U+mlzz11FPm+uuvN0uXLjW7du0yGzduNIsWLTJVVVUmMjLSjB492nz66acmNzfXdO3a1S2cTZw40YSGhppHH33UFBUVmT/84Q8mKCjIvPbaa8YYY7Zt22YcDod58803TWlpqSkoKDCvvPKKMcaYY8eOmQEDBpi0tDTX99PZs2dNTU2NmTlzptm2bZvZs2ePWb58uQkKCjIrV6684n6PHj1qbrzxRvPcc8+52m4qCCxeMmTIEHP77be7np89e9a0bt3aPPDAA65tZWVlRpLJy8szc+bMMXfeeadbG/v373e9MNTl8OHDRpL59NNPjTHnA8tvfvMbV5nPPvvMSDJFRUXX8vBarGs9r5WVlcbPz8+8/fbbrv1Hjx41gYGBlw0sF/rd735nbrjhBtfzJUuWGEluK3DZ2dkmPDy8PodtJU/nYvr06aZnz57G6XS69mdnZ5vg4GBTW1tr8vPzjSRTWlpaZ3/n/rL1RJ8+fVyByJjzP6MX/tUcHR1t3nzzTbdtc+bMMQMGDDDGGPPqq6+aG264wVRXV7v2//rXv/Y4sNxxxx1m7ty5bmWWLVtmIiMjXc8lmRkzZrieV1VVGUnmT3/6kzHGmA8++MBIMv/617+u7ItgqYqKCuPv728WLVp00b7XXnvNXH/99aaqqsq17Y9//KPx9fU15eXlxpivvx+6dOlizp496ypz3333mbFjxxpjjFm9erUJDQ01FRUVdfZ/4SrqpfzoRz9yrcxcSb/GfPvrha24hsWLevfu7fq/w+HQDTfcoPj4eNe28PBwSdKhQ4f0j3/8Qx988IGCg4Mvamf37t3q0aOHSkpKNHPmTG3ZskVHjhyR0+mUJO3bt0+9evWqs9/IyEhXH7Gxsdf2AFuoazmv1dXVqqmpUWJiomt7u3bt1LNnz8uO4S9/+YsyMzNVXFysiooKnT17VqdOndLJkycVFBQkSQoKClJ0dLSrTmRkpA4dOlS/g7aUJ3NRVFSkAQMGyMfHx7V/0KBBqqqq0hdffKE+ffrojjvuUHx8vJKTk3XnnXdqzJgxuv7666/5uG+99VbX/0+cOKHdu3fr4YcfVlpammv72bNnXZ9yW1RUpN69eysgIMC1f8CAAR73+49//EObNm3S888/79pWW1t70ffON7+urVu3VmhoaLP73ikqKtLp06d1xx131LmvT58+at26tWvboEGD5HQ6tWPHDtf31c033yyHw+EqExkZqU8//VSS9P3vf19dunRRt27dNHz4cA0fPlz33nuv62t8KdnZ2Vq8eLH27dvnen248B1ml+u3KSOweNGFF9L5+Pi4bTv3wul0OlVVVaWRI0fqhRdeuKidc6Fj5MiR6tKlixYtWqSOHTvK6XSqV69eqqmpuWS/3+wD18a1nNddu3Z53H9paanuueceTZ48Wc8//7zatWunjz76SA8//LBqampcL4h1jdM0s0/q8GQuvo3D4dCf//xnbd68We+9954WLFigZ555Rlu2bFHXrl2v6bi/+YuwqqpKkrRo0SK34HpuTFfK19f3ovk9c+aM2/OqqirNnj1bo0ePvqj+N8NQXV/X5vYaEhgYeNVtXO7rFBISooKCAm3YsEHvvfeeZs6cqVmzZmnbtm1q27Ztne2tWLFCTzzxhObNm6cBAwYoJCREL774orZs2XLF/TZlBJYmol+/flq9erWioqLUqtXF03b06FHt2LFDixYt0uDBgyVJH330UWMPEx76tnmNjo7Wddddpy1btug73/mOJOlf//qXdu7cqSFDhtTZZn5+vpxOp+bNmydf36/vXPD222833EE0E3FxcVq9erWMMa4gs2nTJoWEhOjGG2+U9PUL/6BBgzRo0CDNnDlTXbp00e9//3ulp6fLz89PtbW113xc4eHh6tixo/bs2aP777//kmNftmyZTp065QoWH3/8sVuZsLAwVVZW6sSJE65A9Pe//92tTL9+/bRjxw7FxMTUe7x+fn6S1CBfi8bUvXt3BQYGKjc3V5MmTXLbFxcXp6VLl7p9LTdt2iRfX99vXf38platWikpKUlJSUnKyMhQ27Zt9f7772v06NF1fj9t2rRJAwcO1GOPPebatnv3bo+PraG+Vxsa92FpIn70ox/pq6++0rhx47Rt2zbt3r1b7777rlJTU1VbW6vrr79eN9xwg1577TXt2rVL77//vtLT0709bHyLb5vX4OBgPfzww3ryySf1/vvvq7CwUA899JAriNQlJiZGZ86c0YIFC7Rnzx4tW7ZMCxcubMSjapoee+wx7d+/Xz/+8Y9VXFysd955RxkZGUpPT5evr6+2bNmiuXPn6m9/+5v27dunnJwcHT58WHFxcZK+vrfFJ598oh07dujIkSMXrV5cjdmzZyszM1O//OUvtXPnTn366adasmSJsrKyJEnjx4+Xj4+P0tLS9Pnnn2vdunV66aWX3NpITExUUFCQpk+frt27d+vNN9/U0qVL3crMnDlTb7zxhmbPnq3PPvtMRUVFWrFihWbMmHHFY+3SpYt8fHy0du1aHT582LVC1NQEBATo6aef1lNPPaU33nhDu3fv1scff6zXX39d999/vwICAjRx4kQVFhbqgw8+0I9//GM98MADrtNB32bt2rX65S9/qb///e/65z//qTfeeENOp9MVeKKiorRlyxaVlpa6TvF3795df/vb3/Tuu+9q586devbZZ7Vt2zaPjy0qKkoffvihvvzySx05csTj+t5CYGkiOnbsqE2bNqm2tlZ33nmn4uPj9dOf/lRt27aVr6+vfH19tWLFCuXn56tXr1762c9+phdffNHbw8a3+LZ5laQXX3xRgwcP1siRI5WUlKTbb79dCQkJl2yzT58+ysrK0gsvvKBevXrp//7v/5SZmdlYh9RkderUSevWrdPWrVvVp08fPfroo3r44Yddv6xDQ0P14YcfasSIEerRo4dmzJihefPm6a677pIkpaWlqWfPnrr11lsVFhamTZs2XbOxTZo0Sb/5zW+0ZMkSxcfHa8iQIVq6dKnrVFRwcLD+8Ic/6NNPP9Utt9yiZ5555qLTjO3atdPy5cu1bt06xcfH66233tKsWbPcyiQnJ2vt2rV677339N3vflf9+/fXyy+/fNn7xFyoU6dOmj17tqZOnarw8HBNmTLlqo/fW5599lk9/vjjmjlzpuLi4jR27FgdOnRIQUFBevfdd/XVV1/pu9/9rsaMGaM77rhD//u//3vFbbdt21Y5OTn6t3/7N8XFxWnhwoV66623dPPNN0uSnnjiCTkcDt10000KCwvTvn379Mgjj2j06NEaO3asEhMTdfToUbfVliv13HPPqbS0VNHR0U3qHk4+prmdtAYAqLS0VF27dtX27du57T+aBVZYAACA9QgsANAA5s6dq+Dg4Dof504jAbhynBICgAbw1Vdf6auvvqpzX2BgoDp16tTIIwKaNgILAACwHqeEAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADr/T8C4M/P+e2XbAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# compare statistical imputation strategies for the horse colic dataset from numpy import mean\n",
+    "from numpy import std\n",
+    "from pandas import read_csv\n",
+    "from sklearn.ensemble import RandomForestClassifier \n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "from sklearn.model_selection import RepeatedStratifiedKFold \n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from matplotlib import pyplot \n",
+    "\n",
+    "# load dataset\n",
+    "horse_colic_data = horse_colic_data_copy\n",
+    "\n",
+    "# split into input and output elements\n",
+    "data = horse_colic_data.values\n",
+    "ix = [i for i in range(data.shape[1]) if i != 23] \n",
+    "X, y = data[:, ix], data[:, 23]\n",
+    "\n",
+    "# evaluate each strategy on the dataset \n",
+    "results = list()\n",
+    "strategies = ['mean', 'median', 'most_frequent', 'constant'] \n",
+    "\n",
+    "for s in strategies:\n",
+    "    # create the modeling pipeline\n",
+    "    pipeline = Pipeline(steps=[('i', SimpleImputer(strategy=s)), ('m', RandomForestClassifier())])\n",
+    "\n",
+    "    # evaluate the model\n",
+    "    cv = RepeatedStratifiedKFold(n_splits=10, n_repeats=3, random_state=1)\n",
+    "    scores = cross_val_score(pipeline, X, y, scoring='accuracy', cv=cv, n_jobs=-1) # store results\n",
+    "    results.append(scores)\n",
+    "    print('>%s %.3f (%.3f)' % (s, mean(scores), std(scores))) \n",
+    "\n",
+    "# plot model performance for comparison \n",
+    "pyplot.boxplot(results, tick_labels=strategies, showmeans=True) \n",
+    "pyplot.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef18f8e2-117c-4680-84b9-e3e23544f856",
+   "metadata": {},
+   "source": [
+    "#### SimpleImputer Transform When Making a Prediction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "1fc920aa-27b0-49b8-8ee4-95e504cc4f73",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted Class: 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# constant imputation strategy and prediction for the horse colic dataset from numpy import nan\n",
+    "from pandas import read_csv\n",
+    "from sklearn.ensemble import RandomForestClassifier \n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "\n",
+    "# load dataset\n",
+    "horse_colic_data = horse_colic_data_copy\n",
+    "\n",
+    "# split into input and output elements\n",
+    "data = horse_colic_data.values\n",
+    "ix = [i for i in range(data.shape[1]) if i != 23] \n",
+    "X, y = data[:, ix], data[:, 23]\n",
+    "\n",
+    "# create the modeling pipeline\n",
+    "pipeline = Pipeline(steps=[('i', SimpleImputer(strategy='constant')), ('m', RandomForestClassifier())])\n",
+    "\n",
+    "# fit the model \n",
+    "pipeline.fit(X, y) \n",
+    "\n",
+    "# define new data\n",
+    "row = [2, 1, 530101, 38.50, 66, 28, 3, 3, np.nan, 2, 5, 4, 4, np.nan, np.nan, np.nan, 3, 5, 45.00, 8.40, np.nan, np.nan, 2, 11300, 00000, 00000, 2]\n",
+    "\n",
+    "# make a prediction\n",
+    "yhat = pipeline.predict([row]) \n",
+    "\n",
+    "# summarize prediction\n",
+    "print('Predicted Class: %d'  % yhat[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffb2b404-8466-4d4b-81a0-7e83bb6d2d23",
+   "metadata": {},
+   "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6644402f-a0f6-45f5-843e-6557fcbd7720",
+   "id": "bec148c8-ffcf-43b3-9525-a38719b687ac",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/Data_preparation.ipynb
+++ b/notebooks/Data_preparation.ipynb
@@ -1505,7 +1505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "id": "3d965e2c-60ae-41fe-b4fc-40fd20f28629",
    "metadata": {},
    "outputs": [
@@ -1560,33 +1560,832 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c9358703-7655-42de-a795-22c7cc0767fd",
+   "cell_type": "markdown",
+   "id": "7fc3f854-b862-44d1-97f2-28ba37bd07ae",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "### How to Use Statistical Imputation"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "id": "36894fd9-0b5f-4bc0-9777-caaec7e06eef",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Shape of horse_colic_data : (300, 28)'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Load datasets\n",
+    "\n",
+    "# Load diabetes data\n",
+    "path_horse_colic= \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/horse-colic.csv\"\n",
+    "\n",
+    "horse_colic_data=pd.read_csv(path_horse_colic,header=None)\n",
+    "display(f\"Shape of horse_colic_data : {horse_colic_data.shape}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "id": "4670e8f5-3942-4620-995a-fd318eabec9c",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "# Copy of datasets\n",
+    "horse_colic_data_copy = horse_colic_data.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "6644402f-a0f6-45f5-843e-6557fcbd7720",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "      <th>4</th>\n",
+       "      <th>5</th>\n",
+       "      <th>6</th>\n",
+       "      <th>7</th>\n",
+       "      <th>8</th>\n",
+       "      <th>9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>18</th>\n",
+       "      <th>19</th>\n",
+       "      <th>20</th>\n",
+       "      <th>21</th>\n",
+       "      <th>22</th>\n",
+       "      <th>23</th>\n",
+       "      <th>24</th>\n",
+       "      <th>25</th>\n",
+       "      <th>26</th>\n",
+       "      <th>27</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530101</td>\n",
+       "      <td>38.50</td>\n",
+       "      <td>66</td>\n",
+       "      <td>28</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>?</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>45.00</td>\n",
+       "      <td>8.40</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>11300</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>534817</td>\n",
+       "      <td>39.2</td>\n",
+       "      <td>88</td>\n",
+       "      <td>20</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>50</td>\n",
+       "      <td>85</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2208</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530334</td>\n",
+       "      <td>38.30</td>\n",
+       "      <td>40</td>\n",
+       "      <td>24</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>33.00</td>\n",
+       "      <td>6.70</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "      <td>5290409</td>\n",
+       "      <td>39.10</td>\n",
+       "      <td>164</td>\n",
+       "      <td>84</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>48.00</td>\n",
+       "      <td>7.20</td>\n",
+       "      <td>3</td>\n",
+       "      <td>5.30</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2208</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530255</td>\n",
+       "      <td>37.30</td>\n",
+       "      <td>104</td>\n",
+       "      <td>35</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>74.00</td>\n",
+       "      <td>7.40</td>\n",
+       "      <td>?</td>\n",
+       "      <td>?</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4300</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 28 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  0   1        2      3    4   5  6  7  8  9   ...     18    19 20    21 22  \\\n",
+       "0  2   1   530101  38.50   66  28  3  3  ?  2  ...  45.00  8.40  ?     ?  2   \n",
+       "1  1   1   534817   39.2   88  20  ?  ?  4  1  ...     50    85  2     2  3   \n",
+       "2  2   1   530334  38.30   40  24  1  1  3  1  ...  33.00  6.70  ?     ?  1   \n",
+       "3  1   9  5290409  39.10  164  84  4  1  6  2  ...  48.00  7.20  3  5.30  2   \n",
+       "4  2   1   530255  37.30  104  35  ?  ?  6  2  ...  74.00  7.40  ?     ?  2   \n",
+       "\n",
+       "  23     24 25 26 27  \n",
+       "0  2  11300  0  0  2  \n",
+       "1  2   2208  0  0  2  \n",
+       "2  2      0  0  0  1  \n",
+       "3  1   2208  0  0  1  \n",
+       "4  2   4300  0  0  2  \n",
+       "\n",
+       "[5 rows x 28 columns]"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Head of data\n",
+    "horse_colic_data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "530684f6-5ef2-4404-8521-8bddc80e162d",
+   "metadata": {},
+   "source": [
+    "Marking missing values with a NaN (not a number) value in a loaded dataset using Python is a best practice. \n",
+    "**We can load the dataset using the read csv() Pandas function and specify the na values to load values of “?” as missing, marked with a NaN value.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "c7079f79-aa25-47ec-8066-b808058fe7f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Shape of horse_colic_data : (300, 28)'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# load dataset\n",
+    "horse_colic_data = read_csv(path_horse_colic, header=None, na_values='?')\n",
+    "display(f\"Shape of horse_colic_data : {horse_colic_data.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "5b772d7f-bef8-4673-9ded-69291e2bdd9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copy of datasets\n",
+    "horse_colic_data_copy = horse_colic_data.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "ecb35143-d5e2-4361-b3b7-38b3f871c71d",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "      <th>4</th>\n",
+       "      <th>5</th>\n",
+       "      <th>6</th>\n",
+       "      <th>7</th>\n",
+       "      <th>8</th>\n",
+       "      <th>9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>18</th>\n",
+       "      <th>19</th>\n",
+       "      <th>20</th>\n",
+       "      <th>21</th>\n",
+       "      <th>22</th>\n",
+       "      <th>23</th>\n",
+       "      <th>24</th>\n",
+       "      <th>25</th>\n",
+       "      <th>26</th>\n",
+       "      <th>27</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530101</td>\n",
+       "      <td>38.5</td>\n",
+       "      <td>66.0</td>\n",
+       "      <td>28.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>8.4</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>11300</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>534817</td>\n",
+       "      <td>39.2</td>\n",
+       "      <td>88.0</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>85.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2208</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530334</td>\n",
+       "      <td>38.3</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>24.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>9</td>\n",
+       "      <td>5290409</td>\n",
+       "      <td>39.1</td>\n",
+       "      <td>164.0</td>\n",
+       "      <td>84.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>48.0</td>\n",
+       "      <td>7.2</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.3</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2208</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>530255</td>\n",
+       "      <td>37.3</td>\n",
+       "      <td>104.0</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>74.0</td>\n",
+       "      <td>7.4</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4300</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 28 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    0   1        2     3      4     5    6    7    8    9   ...    18    19  \\\n",
+       "0  2.0   1   530101  38.5   66.0  28.0  3.0  3.0  NaN  2.0  ...  45.0   8.4   \n",
+       "1  1.0   1   534817  39.2   88.0  20.0  NaN  NaN  4.0  1.0  ...  50.0  85.0   \n",
+       "2  2.0   1   530334  38.3   40.0  24.0  1.0  1.0  3.0  1.0  ...  33.0   6.7   \n",
+       "3  1.0   9  5290409  39.1  164.0  84.0  4.0  1.0  6.0  2.0  ...  48.0   7.2   \n",
+       "4  2.0   1   530255  37.3  104.0  35.0  NaN  NaN  6.0  2.0  ...  74.0   7.4   \n",
+       "\n",
+       "    20   21   22  23     24  25  26  27  \n",
+       "0  NaN  NaN  2.0   2  11300   0   0   2  \n",
+       "1  2.0  2.0  3.0   2   2208   0   0   2  \n",
+       "2  NaN  NaN  1.0   2      0   0   0   1  \n",
+       "3  3.0  5.3  2.0   1   2208   0   0   1  \n",
+       "4  NaN  NaN  2.0   2   4300   0   0   2  \n",
+       "\n",
+       "[5 rows x 28 columns]"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Head of data\n",
+    "horse_colic_data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "3ff2b6ac-73bc-4165-bf43-a5a924f26a1b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 0, Missing: 6 (2.0%)\n",
+      "> 1, Missing: 5 (1.7%)\n",
+      "> 2, Missing: 5 (1.7%)\n",
+      "> 3, Missing: 1 (0.3%)\n",
+      "> 4, Missing: 12 (4.0%)\n",
+      "> 5, Missing: 8 (2.7%)\n",
+      "> 6, Missing: 3 (1.0%)\n",
+      "> 7, Missing: 8 (2.7%)\n",
+      "> 8, Missing: 4 (1.3%)\n",
+      "> 9, Missing: 4 (1.3%)\n",
+      "> 10, Missing: 0 (0.0%)\n",
+      "> 11, Missing: 4 (1.3%)\n",
+      "> 12, Missing: 4 (1.3%)\n",
+      "> 13, Missing: 2 (0.7%)\n",
+      "> 14, Missing: 1 (0.3%)\n",
+      "> 15, Missing: 3 (1.0%)\n",
+      "> 16, Missing: 3 (1.0%)\n",
+      "> 17, Missing: 16 (5.3%)\n",
+      "> 18, Missing: 2 (0.7%)\n",
+      "> 19, Missing: 9 (3.0%)\n",
+      "> 20, Missing: 2 (0.7%)\n",
+      "> 21, Missing: 3 (1.0%)\n",
+      "> 22, Missing: 7 (2.3%)\n",
+      "> 23, Missing: 10 (3.3%)\n",
+      "> 24, Missing: 5 (1.7%)\n",
+      "> 25, Missing: 15 (5.0%)\n",
+      "> 26, Missing: 1 (0.3%)\n",
+      "> 27, Missing: 2 (0.7%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# summarize the number of rows with missing values for each column \n",
+    "for i in range(horse_colic_data.shape[1]):\n",
+    "    # count number of rows with missing values \n",
+    "    n_miss = horse_colic_data.iloc[i].isnull().sum()\n",
+    "    perc = n_miss / horse_colic_data.shape[0] * 100\n",
+    "    perc = round(perc,1)\n",
+    "    print(f'> {i}, Missing: {n_miss} ({perc}%)' )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3d2e73e-1df5-475d-81dc-ed99e2de2ec2",
+   "metadata": {},
+   "source": [
+    "#### Statistical Imputation With SimpleImputer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e65e0ab-30ae-4ad5-8f26-ea4b2290c12b",
+   "metadata": {},
+   "source": [
+    "The scikit-learn machine learning library provides the SimpleImputer class that supports statistical imputation. In this section, we will explore how to effectively use the SimpleImputer class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "78d91352-22f4-420b-b2ce-1dc1825a65ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Missing:  1605\n",
+      "Missing:  0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# statistical imputation transform for the horse colic dataset from numpy import isnan\n",
+    "from pandas import read_csv\n",
+    "from sklearn.impute import SimpleImputer\n",
+    "\n",
+    "# load dataset\n",
+    "horse_colic_data = horse_colic_data_copy\n",
+    "\n",
+    "# split into input and output elements\n",
+    "data = horse_colic_data.values\n",
+    "ix = [i for i in range(data.shape[1]) if i != 23] \n",
+    "X, y = data[:, ix], data[:, 23]\n",
+    "\n",
+    "# summarize total missing\n",
+    "print(f\"Missing:  {sum(np.isnan(X).flatten())}\") \n",
+    "\n",
+    "# define imputer\n",
+    "imputer = SimpleImputer(strategy='mean') \n",
+    "\n",
+    "# fit on the dataset\n",
+    "imputer.fit(X)\n",
+    "\n",
+    "# transform the dataset \n",
+    "Xtrans = imputer.transform(X) \n",
+    "\n",
+    "# summarize total missing\n",
+    "print(f\"Missing:  {sum(np.isnan(Xtrans).flatten())}\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7d96484-7dfe-4b7b-a1c0-5fde2227b745",
+   "metadata": {},
+   "source": [
+    "#### SimpleImputer and Model Evaluation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54ad368b-e34d-49db-bf6f-ebff617bbd47",
+   "metadata": {},
+   "source": [
+    "It is a good practice to evaluate machine learning models on a dataset using k-fold cross- validation. **To correctly apply statistical missing data imputation and avoid data leakage**, it is required that the statistics calculated for each column are calculated on the training dataset only, then applied to the train and test sets for each fold in the dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be3f39e3-cab8-4e77-a42f-fc4ab25e2406",
+   "metadata": {},
+   "source": [
+    "This can be achieved by creating a modeling pipeline where the first step is the statistical imputation, then the second step is the model. This can be achieved using the Pipeline class. For example, the Pipeline below uses a SimpleImputer with a ‘mean’ strategy, followed by a random forest model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "0d49e1ba-b2f9-4335-8ebd-1d180d6c3b5b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mean Accuracy: 0.857 (0.052)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# evaluate mean imputation and random forest for the horse colic dataset from numpy import mean\n",
+    "from numpy import std\n",
+    "from pandas import read_csv\n",
+    "from sklearn.ensemble import RandomForestClassifier \n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "from sklearn.model_selection import RepeatedStratifiedKFold \n",
+    "from sklearn.pipeline import Pipeline\n",
+    "\n",
+    "# load dataset\n",
+    "horse_colic_data = horse_colic_data_copy\n",
+    "\n",
+    "# split into input and output elements\n",
+    "data = horse_colic_data.values\n",
+    "ix = [i for i in range(data.shape[1]) if i != 23] \n",
+    "X, y = data[:, ix], data[:, 23]\n",
+    "\n",
+    "# define modeling pipeline\n",
+    "model = RandomForestClassifier()\n",
+    "imputer = SimpleImputer(strategy='mean')\n",
+    "pipeline = Pipeline(steps=[('i', imputer), ('m', model)]) \n",
+    "\n",
+    "# define model evaluation\n",
+    "cv = RepeatedStratifiedKFold(n_splits=10, n_repeats=3, random_state=1) \n",
+    "\n",
+    "# evaluate model\n",
+    "scores = cross_val_score(pipeline, X, y, scoring='accuracy', cv=cv, n_jobs=-1) \n",
+    "print(f'Mean Accuracy: {round(mean(scores),3)} ({round(std(scores),3)})')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5ef1573-c9c9-489c-a16e-cb4336013bb4",
+   "metadata": {},
+   "source": [
+    "#### Comparing Different Imputed Statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "daf39d4d-fdb0-4703-8302-428d1abb4145",
+   "metadata": {},
+   "source": [
+    "How do we know that using a ‘mean’ statistical strategy is good or best for this dataset? The answer is that we don’t and that it was chosen arbitrarily. We can design an experiment to test each statistical strategy and discover what works best for this dataset, comparing the mean, median, mode (most frequent), and constant (0) strategies. The mean accuracy of each approach can then be compared. The complete example is listed below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "0cc8d6e2-a1f4-48e1-b5b0-eb6ba13cf6d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">mean 0.867 (0.054)\n",
+      ">median 0.873 (0.057)\n",
+      ">most_frequent 0.866 (0.062)\n",
+      ">constant 0.876 (0.047)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGdCAYAAAAxCSikAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAMutJREFUeJzt3X9c1fXB//8nHOOXgGYioDlRUKFETVr4I6desTDLS/Kyy2mWcSUrm7u20S81E80lVyvJ5sVmudSlV2lTZt85Z22Uy5TUgVtRoPiDaQn+agooinJenz/6euwomgeF8wIe99vt3PS8369fb15wePJ6v8/7+BhjjAAAACzm6+0BAAAAfBsCCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAeq28PYBrwel06sCBAwoJCZGPj4+3hwMAAK6AMUaVlZXq2LGjfH0vv4bSLALLgQMH1LlzZ28PAwAA1MP+/ft14403XrZMswgsISEhkr4+4NDQUC+PBgAAXImKigp17tzZ9Xv8cppFYDl3Gig0NJTAAgBAE3Mll3Nw0S0AALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYL1mceM4AACaqtraWm3cuFFlZWWKjIzU4MGD5XA4vD0s67DCAgCAl+Tk5CgmJkbDhg3T+PHjNWzYMMXExCgnJ8fbQ7MOgQUAAC/IycnRmDFjFB8fr7y8PFVWViovL0/x8fEaM2YMoeUCPsYY4+1BXK2Kigq1adNGx48f57OEAADWq62tVUxMjOLj47VmzRr5+p5fP3A6nUpJSVFhYaFKSkqa9ekhT35/cw2LJU6ePKni4mKP6lRXV6u0tFRRUVEKDAz0uM/Y2FgFBQV5XA9Xj/luWZhvXGjjxo0qLS3VW2+95RZWJMnX11fTpk3TwIEDtXHjRg0dOtQ7g7QMgcUSxcXFSkhIaNQ+8/Pz1a9fv0btE19jvlsW5hsXKisrkyT16tWrzv3ntp8rBwKLNWJjY5Wfn+9RnaKiIk2YMEHLly9XXFxcvfqEdzDfLQvzjQtFRkZKkgoLC9W/f/+L9hcWFrqVA4HFGkFBQfX+ayguLo6/pJoY5rtlYb5xocGDBysqKkpz586t8xqWzMxMde3aVYMHD/biKO3Cu4QAAGhkDodD8+bN09q1a5WSkuL2LqGUlBStXbtWL730UrO+4NZTrLAAAOAFo0eP1qpVq/T4449r4MCBru1du3bVqlWrNHr0aC+Ozj4EFgAAvGT06NEaNWoUd7q9AgQWAAC8yOFw8NblK8A1LAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsV6/Akp2draioKAUEBCgxMVFbt269ZNkzZ87oueeeU3R0tAICAtSnTx+tX7/ercysWbPk4+Pj9oiNja3P0AAAQDPkcWBZuXKl0tPTlZGRoYKCAvXp00fJyck6dOhQneVnzJihV199VQsWLNDnn3+uRx99VPfee6+2b9/uVu7mm29WWVmZ6/HRRx/V74gAAECz43FgycrKUlpamlJTU3XTTTdp4cKFCgoK0uLFi+ssv2zZMk2fPl0jRoxQt27dNHnyZI0YMULz5s1zK9eqVStFRES4Hu3bt6/fEQEAgGbHo8BSU1Oj/Px8JSUlnW/A11dJSUnKy8urs87p06cVEBDgti0wMPCiFZSSkhJ17NhR3bp10/333699+/ZdchynT59WRUWF2wMAADRfHgWWI0eOqLa2VuHh4W7bw8PDVV5eXmed5ORkZWVlqaSkRE6nU3/+85+Vk5OjsrIyV5nExEQtXbpU69ev169//Wvt3btXgwcPVmVlZZ1tZmZmqk2bNq5H586dPTkMAADQxDT4u4ReeeUVde/eXbGxsfLz89OUKVOUmpoqX9/zXd91112677771Lt3byUnJ2vdunU6duyY3n777TrbnDZtmo4fP+567N+/v6EPAwAAeJFHgaV9+/ZyOBw6ePCg2/aDBw8qIiKizjphYWFas2aNTpw4oX/+858qLi5WcHCwunXrdsl+2rZtqx49emjXrl117vf391doaKjbAwAANF8eBRY/Pz8lJCQoNzfXtc3pdCo3N1cDBgy4bN2AgAB16tRJZ8+e1erVqzVq1KhLlq2qqtLu3bsVGRnpyfAAAEAz5fEpofT0dC1atEi//e1vVVRUpMmTJ+vEiRNKTU2VJD344IOaNm2aq/yWLVuUk5OjPXv2aOPGjRo+fLicTqeeeuopV5knnnhCf/3rX1VaWqrNmzfr3nvvlcPh0Lhx467BIQIAgKaulacVxo4dq8OHD2vmzJkqLy9X3759tX79eteFuPv27XO7PuXUqVOaMWOG9uzZo+DgYI0YMULLli1T27ZtXWW++OILjRs3TkePHlVYWJhuv/12ffzxxwoLC7v6IwQAAE2ex4FFkqZMmaIpU6bUuW/Dhg1uz4cMGaLPP//8su2tWLGiPsMAAAAtBJ8lBAAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFivlbcHAABAc3Ly5EkVFxd7VKe6ulqlpaWKiopSYGCgx33GxsYqKCjI43pNCYEFAIBrqLi4WAkJCY3aZ35+vvr169eofTY2AgsAANdQbGys8vPzPapTVFSkCRMmaPny5YqLi6tXn80dgQUAgGsoKCio3qsdcXFxzX6lpL646BYAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYr16BJTs7W1FRUQoICFBiYqK2bt16ybJnzpzRc889p+joaAUEBKhPnz5av379VbUJAABaFo8Dy8qVK5Wenq6MjAwVFBSoT58+Sk5O1qFDh+osP2PGDL366qtasGCBPv/8cz366KO69957tX379nq3CQAAWhaPA0tWVpbS0tKUmpqqm266SQsXLlRQUJAWL15cZ/lly5Zp+vTpGjFihLp166bJkydrxIgRmjdvXr3bBAAALUsrTwrX1NQoPz9f06ZNc23z9fVVUlKS8vLy6qxz+vRpBQQEuG0LDAzURx99dFVtnj592vW8oqLCk8NocCUlJaqsrGzwfoqKitz+bQwhISHq3r17o/XXFOz5JE+nj/yzwfsp37tXt0T4qnz7uyo6trPB+5Mk//Zd1K33gEbpq6ng57tlYb7t4VFgOXLkiGpraxUeHu62PTw8XMXFxXXWSU5OVlZWlr73ve8pOjpaubm5ysnJUW1tbb3bzMzM1OzZsz0ZeqMpKSlRjx49GrXPCRMmNGp/O3fubFLf5A2ppKRE//ffwzRrqH+D9xUnacQjwdL+/5H2N3h3kqRZG07r/kWfMt//P36+Wxbm2y4eBZb6eOWVV5SWlqbY2Fj5+PgoOjpaqampV3W6Z9q0aUpPT3c9r6ioUOfOna/FcK/auSS+fPlyxcXFNWhf1dXVKi0tVVRUlAIDAxu0L+nr5D9hwoRG+WujqaisrNSr+TW67YEMde3atUH7On36tA4cOKCOHTvK37/hA9LevXv1av4z+nfm24Wf75aF+baLR4Glffv2cjgcOnjwoNv2gwcPKiIios46YWFhWrNmjU6dOqWjR4+qY8eOmjp1qrp161bvNv39/RvlBftqxMXFqV+/fg3ez6BBgxq8D1xeeZVRxC3JimuE+e7b4D2cV11QoPKq6Y3YY9PBz3fLwnzbwaOLbv38/JSQkKDc3FzXNqfTqdzcXA0YcPnz3AEBAerUqZPOnj2r1atXa9SoUVfdJgAAaBk8PiWUnp6uiRMn6tZbb9Vtt92m+fPn68SJE0pNTZUkPfjgg+rUqZMyMzMlSVu2bNGXX36pvn376ssvv9SsWbPkdDr11FNPXXGbAACgZfM4sIwdO1aHDx/WzJkzVV5err59+2r9+vWui2b37dsnX9/zCzenTp3SjBkztGfPHgUHB2vEiBFatmyZ2rZte8VtAgCAlq1eF91OmTJFU6ZMqXPfhg0b3J4PGTJEn3/++VW1CQAAWjY+SwgAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwXitvDwAAmpKIYB8FHtspHWhef+8FHtupiGAfbw8DuCQCCwB44JEEP8V9+Ij0obdHcm3F6etjA2xFYAEAD7yaX6OxM5cqLjbW20O5poqKi/XqvPH6d28PBLgEAgsAeKC8yqi6bQ+pY19vD+Waqi53qrzKeHsYwCU1r5OwAACgWSKwAAAA6xFYAACA9QgsAADAegQWAABgPQILAABelncgT6PWjFLegTxvD8VaBBYAALzIGKNXCl7RnuN79ErBKzKGt5fXhcACAIAXbT6wWZ8d/UyS9NnRz7T5wGYvj8hOBBagiWDJGGh+jDFasH2BfH2+/nXs6+OrBdsXsMpSBwIL0ASwZAw0T+dWV5zGKUlyGierLJdAYAGaAJaMgebnwtWVc1hlqRuBBbAcS8ZA83Th6so5rLLUjcACWI4lY6D5OfeHiI986tzvIx/+MLkAgQWwGEvGQPN0xnlG5SfKZVT3z7CRUfmJcp1xnmnkkdmrlbcHAODSvnntyjd9c5VlUKdBXhgZgKvh5/DTintW6KtTX12yTLuAdvJz+DXiqOxGYAEs9c0l47r+Cju3ZDyw40D5+NS9rAzAXhGtIxTROsLbw2gyOCUEWIolYwA4jxWWJizvQJ7+Z+v/aOptUzWg4wBvDwfXGEvGAHAegaWJuvBGYv0j+3NaoBliyRgAvsYpoSaKG4kBzRsfxQC4Y4WlAUQE+yjw2E7pQMPkQWOMFmx9Qb7ylVNO+cpXC7a+oIG3zW7QVZbAYzsVEcwqDtDQWEG1w8mTJxUR7KN/fvz/ff2a3oBOnz6tAwcOqGPHjvL392/QviSpfO/eJvd6TmBpAI8k+Cnuw0ekDxum/c2BAfosooPruVNOfVaxV5uXD9eg6lMN06mkOH19bAAaVl0rqLx9vfEVFxfrkQQ/3XvoZelQw/fXV5L2N3w/0vnX85CQkMbp8BogsDSAV/NrNHbmUsXFxl7ztr9eXcmQb8U/5dT52zn7ylcLeiQ26CpLUXGxXp03Xv/eIK0DkNxvFug0TtdNAnn7euNLSUnRu7UV2t65nQICAhq0r71792rGjBn6+c9/rq5duzZoX+c8OLqLunXv3ih9XQsElgZQXmVU3baH1LHvNW9785eb9FnF3ou2u1ZZdFKDOjbMX2LV5U6VV3FnVaAhXXizQG4S6D3t27fX/Y+kN0pf1QUF2l4+XRG3JCuuX79G6bOp4aLbJoTPngCaNz6KAbg0AksTwo3EgOaNT+8FLo1TQk0INxIDmi8+igG4PAJLE8ONxIDmyZMVVP4oQUtEYAEAC7CCClwegQUALMEKKnBpXHQLAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOvVK7BkZ2crKipKAQEBSkxM1NatWy9bfv78+erZs6cCAwPVuXNn/exnP9OpU6dc+2fNmiUfHx+3R2xsbH2GBgAAmiGPP/xw5cqVSk9P18KFC5WYmKj58+crOTlZO3bsUIcOHS4q/+abb2rq1KlavHixBg4cqJ07d+qhhx6Sj4+PsrKyXOVuvvlm/eUvfzk/sFZ8LiMAAPiaxyssWVlZSktLU2pqqm666SYtXLhQQUFBWrx4cZ3lN2/erEGDBmn8+PGKiorSnXfeqXHjxl20KtOqVStFRES4Hu3bt6/fEQEAgGbHo8BSU1Oj/Px8JSUlnW/A11dJSUnKy8urs87AgQOVn5/vCih79uzRunXrNGLECLdyJSUl6tixo7p166b7779f+/btu+Q4Tp8+rYqKCrcHAABovjw673LkyBHV1tYqPDzcbXt4eLiKi4vrrDN+/HgdOXJEt99+u4wxOnv2rB599FFNnz7dVSYxMVFLly5Vz549VVZWptmzZ2vw4MEqLCxUSEjIRW1mZmZq9uzZngwdAAA0YQ3+LqENGzZo7ty5+tWvfqWCggLl5OToj3/8o+bMmeMqc9ddd+m+++5T7969lZycrHXr1unYsWN6++2362xz2rRpOn78uOuxf//+hj4MAADgRR6tsLRv314Oh0MHDx50237w4EFFRETUWefZZ5/VAw88oEmTJkmS4uPjdeLECf3whz/UM888I1/fizNT27Zt1aNHD+3atavONv39/eXv7+/J0AEAQBPm0QqLn5+fEhISlJub69rmdDqVm5urAQMG1Fnn5MmTF4USh8MhSTLG1FmnqqpKu3fvVmRkpCfDAwAAzZTH7x1OT0/XxIkTdeutt+q2227T/PnzdeLECaWmpkqSHnzwQXXq1EmZmZmSpJEjRyorK0u33HKLEhMTtWvXLj377LMaOXKkK7g88cQTGjlypLp06aIDBw4oIyNDDodD48aNu4aHCgAAmiqPA8vYsWN1+PBhzZw5U+Xl5erbt6/Wr1/vuhB33759bisqM2bMkI+Pj2bMmKEvv/xSYWFhGjlypJ5//nlXmS+++ELjxo3T0aNHFRYWpttvv10ff/yxwsLCrsEhAgCApq5ed2ebMmWKpkyZUue+DRs2uHfQqpUyMjKUkZFxyfZWrFhRn2EAAIAWgs8SAgAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKzXytsDaG5OnjwpSSooKGjwvqqrq1VaWqqoqCgFBgY2eH9FRUUN3gcANHUnT55UcXGxR3XOvb7W93U2NjZWQUFB9arbVBBYrrFz36RpaWleHknDCQkJ8fYQAMBaxcXFSkhIqFfdCRMm1Ktefn6++vXrV6+6TQWB5RpLSUmR1Dhpt6ioSBMmTNDy5csVFxfXoH2dExISou7duzdKXwDQFMXGxio/P9+jOle7Yh4bG+txnaaGwHKNtW/fXpMmTWrUPuPi4pp9sgaApiIoKKher8mDBg1qgNE0H1x0CwAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYr5W3BwA0ZSdPnpQkFRQUNHhf1dXVKi0tVVRUlAIDAxu8v6Kiogbvo6lhvgHvIbAAV6G4uFiSlJaW5uWRNJyQkBBvD8EazDfgPQQW4CqkpKRIkmJjYxUUFNSgfRUVFWnChAlavny54uLiGrSvc0JCQtS9e/dG6aspYL4B7yGwAFehffv2mjRpUqP2GRcXp379+jVqn/ga8w14DxfdAgAA6xFYAACA9QgsAADAegQWAABgPQILAABeVF1drSlTpig5OVlTpkxRdXW1t4dkpXoFluzsbEVFRSkgIECJiYnaunXrZcvPnz9fPXv2VGBgoDp37qyf/exnOnXq1FW1CQBAU5eSkqKgoCBlZ2frvffeU3Z2toKCglxvocd5HgeWlStXKj09XRkZGSooKFCfPn2UnJysQ4cO1Vn+zTff1NSpU5WRkaGioiK9/vrrWrlypaZPn17vNgEAaOpSUlL0zjvvyM/PT1OnTtWuXbs0depU+fn56Z133iG0XMDjwJKVlaW0tDSlpqbqpptu0sKFCxUUFKTFixfXWX7z5s0aNGiQxo8fr6ioKN15550aN26c2wqKp20CANCUVVdXu8JKZWWlMjMzFR0drczMTFVWVrpCC6eHzvMosNTU1Cg/P19JSUnnG/D1VVJSkvLy8uqsM3DgQOXn57sCyp49e7Ru3TqNGDGi3m2ePn1aFRUVbg8AAJqKJ598UpKUnp4uPz8/t31+fn766U9/6lYOHgaWI0eOqLa2VuHh4W7bw8PDVV5eXmed8ePH67nnntPtt9+u6667TtHR0Ro6dKjrlFB92szMzFSbNm1cj86dO3tyGAAAeFVJSYkkXfLOyQ8//LBbOTTCu4Q2bNiguXPn6le/+pUKCgqUk5OjP/7xj5ozZ06925w2bZqOHz/ueuzfv/8ajhgAgIZ17jObfvOb39S5//XXX3crBw8DS/v27eVwOHTw4EG37QcPHlRERESddZ599lk98MADmjRpkuLj43Xvvfdq7ty5yszMlNPprFeb/v7+Cg0NdXsAANBUvPjii5K+voazpqbGbV9NTY3mz5/vVg4eBhY/Pz8lJCQoNzfXtc3pdCo3N1cDBgyos87Jkyfl6+vejcPhkCQZY+rVJgAATVlgYKBGjRqlmpoahYSE6Omnn9bOnTv19NNPKyQkRDU1NRo1apQCAwO9PVRrePxpzenp6Zo4caJuvfVW3XbbbZo/f75OnDih1NRUSdKDDz6oTp06KTMzU5I0cuRIZWVl6ZZbblFiYqJ27dqlZ599ViNHjnQFl29rEwCA5mbNmjWutzb/4he/0C9+8QvXvlGjRmnNmjXeG5yFPA4sY8eO1eHDhzVz5kyVl5erb9++Wr9+veui2X379rmtqMyYMUM+Pj6aMWOGvvzyS4WFhWnkyJF6/vnnr7hNAACaozVr1qi6ulpPPvmkSkpK1L17d7344ousrNTBxxhjvD2Iq1VRUaE2bdro+PHjLep6loKCAiUkJCg/P1/9+vXz9nDQwJjvloX5Rkvgye9vPksIAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1iOwAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOu18vYAAABoyWpra7Vx40aVlZUpMjJSgwcPlsPh8PawrMMKCwAAXpKTk6OYmBgNGzZM48eP17BhwxQTE6OcnBxvD806BBYAALwgJydHY8aMUXx8vPLy8lRZWam8vDzFx8drzJgxhJYLEFgAAGhktbW1evzxx3XPPfdozZo16t+/v4KDg9W/f3+tWbNG99xzj5544gnV1tZ6e6jW4BoWS5w8eVLFxcUe1SkqKnL711OxsbEKCgqqV11cHeYbaNk2btyo0tJSvfXWW/L1dV878PX11bRp0zRw4EBt3LhRQ4cO9c4gLUNgsURxcbESEhLqVXfChAn1qpefn69+/frVqy6uDvMNtGxlZWWSpF69etW5/9z2c+VAYLFGbGys8vPzPapTXV2t0tJSRUVFKTAwsF59wjuYb6Bli4yMlCQVFhaqf//+F+0vLCx0KwfJxxhjvD2Iq1VRUaE2bdro+PHjCg0N9fZwAOCqFRQUKCEhgZWxZqq2tlYxMTGKj4/XmjVr3E4LOZ1OpaSkqLCwUCUlJc36Lc6e/P7molsAABqZw+HQvHnztHbtWqWkpLi9SyglJUVr167VSy+91KzDiqc4JQQAgBeMHj1aq1at0uOPP66BAwe6tnft2lWrVq3S6NGjvTg6+xBYAADwktGjR2vUqFHc6fYKEFgAAPAih8PBW5evANewAAAA6xFYAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALBevQJLdna2oqKiFBAQoMTERG3duvWSZYcOHSofH5+LHnfffberzEMPPXTR/uHDh9dnaAAAoBlq5WmFlStXKj09XQsXLlRiYqLmz5+v5ORk7dixQx06dLiofE5OjmpqalzPjx49qj59+ui+++5zKzd8+HAtWbLE9dzf39/ToQEAgGbK4xWWrKwspaWlKTU1VTfddJMWLlyooKAgLV68uM7y7dq1U0REhOvx5z//WUFBQRcFFn9/f7dy119/ff2OCAAANDseBZaamhrl5+crKSnpfAO+vkpKSlJeXt4VtfH666/rBz/4gVq3bu22fcOGDerQoYN69uypyZMn6+jRo5ds4/Tp06qoqHB7AACA5sujwHLkyBHV1tYqPDzcbXt4eLjKy8u/tf7WrVtVWFioSZMmuW0fPny43njjDeXm5uqFF17QX//6V911112qra2ts53MzEy1adPG9ejcubMnhwEAAJoYj69huRqvv/664uPjddttt7lt/8EPfuD6f3x8vHr37q3o6Ght2LBBd9xxx0XtTJs2Tenp6a7nFRUVhBYAAJoxj1ZY2rdvL4fDoYMHD7ptP3jwoCIiIi5b98SJE1qxYoUefvjhb+2nW7duat++vXbt2lXnfn9/f4WGhro9AABA8+VRYPHz81NCQoJyc3Nd25xOp3JzczVgwIDL1v3d736n06dPa8KECd/azxdffKGjR48qMjLSk+EBAIBmyuN3CaWnp2vRokX67W9/q6KiIk2ePFknTpxQamqqJOnBBx/UtGnTLqr3+uuvKyUlRTfccIPb9qqqKj355JP6+OOPVVpaqtzcXI0aNUoxMTFKTk6u52EBAIDmxONrWMaOHavDhw9r5syZKi8vV9++fbV+/XrXhbj79u2Tr697DtqxY4c++ugjvffeexe153A49Mknn+i3v/2tjh07po4dO+rOO+/UnDlzuBcLAACQJPkYY4y3B3G1Kioq1KZNGx0/fpzrWQA0CwUFBUpISFB+fr769evn7eEADcKT3998lhAAALAegQUAAFiPwAIAAKxHYAEAANYjsAAAAOsRWAAAgPUILAAAwHoEFgAAYD0CCwAAsB6BBQAAWI/AAgAArEdgAQAA1vP405phh9raWm3cuFFlZWWKjIzU4MGD5XA4vD0sAAAaBCssTVBOTo5iYmI0bNgwjR8/XsOGDVNMTIxycnK8PTQAABoEgaWJycnJ0ZgxYxQfH6+8vDxVVlYqLy9P8fHxGjNmDKEFANAs+RhjjLcHcbUqKirUpk0bHT9+XKGhod4eToOpra1VTEyM4uPjtWbNGvn6ns+bTqdTKSkpKiwsVElJCaeHgCauoKBACQkJys/PV79+/bw9HKBBePL7m2tYmpCNGzeqtLRUb731lltYkSRfX19NmzZNAwcO1MaNGzV06FDvDBLARU6ePKni4mKP6hQVFbn966nY2FgFBQXVqy5gIwJLE1JWViZJ6tWrV537z20/Vw6AHYqLi5WQkFCvuhMmTKhXPVZm0NwQWJqQyMhISVJhYaH69+9/0f7CwkK3cgDsEBsbq/z8fI/qVFdXq7S0VFFRUQoMDKxXn0BzwjUsTQjXsAAAmhNPfn/zLqEmxOFwaN68eVq7dq1SUlLc3iWUkpKitWvX6qWXXiKsAACaHU4JNTGjR4/WqlWr9Pjjj2vgwIGu7V27dtWqVas0evRoL44OAICGwSmhJoo73QIAmjre1twCOBwO3roMAGgxuIYFAABYj8ACAACsR2ABAADWI7AAAADrEVgAAID1CCwAAMB6BBYAAGA9AgsAALAegQUAAFivWdzp9tynC1RUVHh5JAAA4Eqd+719JZ8S1CwCS2VlpSSpc+fOXh4JAADwVGVlpdq0aXPZMs3iww+dTqcOHDigkJAQ+fj4eHs4jaaiokKdO3fW/v37W8yHPrZkzHfLwny3LC11vo0xqqysVMeOHeXre/mrVJrFCouvr69uvPFGbw/Da0JDQ1vUN3hLx3y3LMx3y9IS5/vbVlbO4aJbAABgPQILAACwHoGlCfP391dGRob8/f29PRQ0Aua7ZWG+Wxbm+9s1i4tuAQBA88YKCwAAsB6BBQAAWI/AAgAArEdgAZqgoUOH6qc//anreVRUlObPn++18aB+iouL1b9/fwUEBKhv377eHg5gNQIL0Axs27ZNP/zhD709jBbtoYceUkpKikd1MjIy1Lp1a+3YsUO5ubkNM7BGtmHDBvn4+OjYsWPeHkqTduEfJddSU/0Dp1nc6RZo6cLCwrw9BNTD7t27dffdd6tLly6XLHPmzBldd911jTgqwFIGXjFkyBAzZcoU85Of/MS0bdvWdOjQwbz22mumqqrKPPTQQyY4ONhER0ebdevWuep8+umnZvjw4aZ169amQ4cOZsKECebw4cOu/X/605/MoEGDTJs2bUy7du3M3XffbXbt2uXav3fvXiPJrF692gwdOtQEBgaa3r17m82bNzfqsTdnDTGvVVVV5oEHHjCtW7c2ERER5qWXXjJDhgwxP/nJT1xlunTpYl5++WXX83nz5plevXqZoKAgc+ONN5rJkyebyspK1/4lS5aYNm3amPXr15vY2FjTunVrk5ycbA4cONCgX5/GVJ+52LBhg/nud79r/Pz8TEREhHn66afNmTNnXPt/97vfmV69epmAgADTrl07c8cdd5iqqiqTkZFhJLk9Pvjgg8uO78LyGRkZrp/RFStWmO9973vG39/fLFmyxBhjzKJFi0xsbKzx9/c3PXv2NNnZ2W7tbdmyxfTt29f4+/ubhIQEk5OTYySZ7du3G2POz/k3/f73vzcX/hpYs2aNueWWW4y/v7/p2rWrmTVrltvXQJJZtGiRSUlJMYGBgSYmJsa88847xpjzrzHffEycOPEKZstOtbW15oUXXjDR0dHGz8/PdO7c2fz85z83xhjzySefmGHDhrm+F9LS0tx+xiZOnGhGjRplXnzxRRMREWHatWtnHnvsMVNTU+Mqk52dbWJiYoy/v7/p0KGD+Y//+A9X3Qu/jnv37jVnz541//Vf/2WioqJMQECA6dGjh5k/f77bmL+t3yFDhlzUdlPRdEbazAwZMsSEhISYOXPmmJ07d5o5c+YYh8Nh7rrrLvPaa6+ZnTt3msmTJ5sbbrjBnDhxwvzrX/8yYWFhZtq0aaaoqMgUFBSY73//+2bYsGGuNletWmVWr15tSkpKzPbt283IkSNNfHy8qa2tNcacfzGJjY01a9euNTt27DBjxowxXbp0cXtBQv01xLxOnjzZfOc73zF/+ctfzCeffGLuueceExISctnA8vLLL5v333/f7N271+Tm5pqePXuayZMnu/YvWbLEXHfddSYpKcls27bN5Ofnm7i4ODN+/PjG+DI1Ck/n4osvvjBBQUHmscceM0VFReb3v/+9ad++vcnIyDDGGHPgwAHTqlUrk5WVZfbu3Ws++eQTk52dbSorK01lZaX5z//8TzN8+HBTVlZmysrKzOnTpy87vrKyMnPzzTebxx9/3JSVlZnKykrXz2hUVJRZvXq12bNnjzlw4IBZvny5iYyMdG1bvXq1adeunVm6dKkxxpjKykoTFhZmxo8fbwoLC80f/vAH061bN48Dy4cffmhCQ0PN0qVLze7du817771noqKizKxZs1xlJJkbb7zRvPnmm6akpMT893//twkODjZHjx41Z8+eNatXrzaSzI4dO0xZWZk5duzY1U+mlzz11FPm+uuvN0uXLjW7du0yGzduNIsWLTJVVVUmMjLSjB492nz66acmNzfXdO3a1S2cTZw40YSGhppHH33UFBUVmT/84Q8mKCjIvPbaa8YYY7Zt22YcDod58803TWlpqSkoKDCvvPKKMcaYY8eOmQEDBpi0tDTX99PZs2dNTU2NmTlzptm2bZvZs2ePWb58uQkKCjIrV6684n6PHj1qbrzxRvPcc8+52m4qCCxeMmTIEHP77be7np89e9a0bt3aPPDAA65tZWVlRpLJy8szc+bMMXfeeadbG/v373e9MNTl8OHDRpL59NNPjTHnA8tvfvMbV5nPPvvMSDJFRUXX8vBarGs9r5WVlcbPz8+8/fbbrv1Hjx41gYGBlw0sF/rd735nbrjhBtfzJUuWGEluK3DZ2dkmPDy8PodtJU/nYvr06aZnz57G6XS69mdnZ5vg4GBTW1tr8vPzjSRTWlpaZ3/n/rL1RJ8+fVyByJjzP6MX/tUcHR1t3nzzTbdtc+bMMQMGDDDGGPPqq6+aG264wVRXV7v2//rXv/Y4sNxxxx1m7ty5bmWWLVtmIiMjXc8lmRkzZrieV1VVGUnmT3/6kzHGmA8++MBIMv/617+u7ItgqYqKCuPv728WLVp00b7XXnvNXH/99aaqqsq17Y9//KPx9fU15eXlxpivvx+6dOlizp496ypz3333mbFjxxpjjFm9erUJDQ01FRUVdfZ/4SrqpfzoRz9yrcxcSb/GfPvrha24hsWLevfu7fq/w+HQDTfcoPj4eNe28PBwSdKhQ4f0j3/8Qx988IGCg4Mvamf37t3q0aOHSkpKNHPmTG3ZskVHjhyR0+mUJO3bt0+9evWqs9/IyEhXH7Gxsdf2AFuoazmv1dXVqqmpUWJiomt7u3bt1LNnz8uO4S9/+YsyMzNVXFysiooKnT17VqdOndLJkycVFBQkSQoKClJ0dLSrTmRkpA4dOlS/g7aUJ3NRVFSkAQMGyMfHx7V/0KBBqqqq0hdffKE+ffrojjvuUHx8vJKTk3XnnXdqzJgxuv7666/5uG+99VbX/0+cOKHdu3fr4YcfVlpammv72bNnXZ9yW1RUpN69eysgIMC1f8CAAR73+49//EObNm3S888/79pWW1t70ffON7+urVu3VmhoaLP73ikqKtLp06d1xx131LmvT58+at26tWvboEGD5HQ6tWPHDtf31c033yyHw+EqExkZqU8//VSS9P3vf19dunRRt27dNHz4cA0fPlz33nuv62t8KdnZ2Vq8eLH27dvnen248B1ml+u3KSOweNGFF9L5+Pi4bTv3wul0OlVVVaWRI0fqhRdeuKidc6Fj5MiR6tKlixYtWqSOHTvK6XSqV69eqqmpuWS/3+wD18a1nNddu3Z53H9paanuueceTZ48Wc8//7zatWunjz76SA8//LBqampcL4h1jdM0s0/q8GQuvo3D4dCf//xnbd68We+9954WLFigZ555Rlu2bFHXrl2v6bi/+YuwqqpKkrRo0SK34HpuTFfK19f3ovk9c+aM2/OqqirNnj1bo0ePvqj+N8NQXV/X5vYaEhgYeNVtXO7rFBISooKCAm3YsEHvvfeeZs6cqVmzZmnbtm1q27Ztne2tWLFCTzzxhObNm6cBAwYoJCREL774orZs2XLF/TZlBJYmol+/flq9erWioqLUqtXF03b06FHt2LFDixYt0uDBgyVJH330UWMPEx76tnmNjo7Wddddpy1btug73/mOJOlf//qXdu7cqSFDhtTZZn5+vpxOp+bNmydf36/vXPD222833EE0E3FxcVq9erWMMa4gs2nTJoWEhOjGG2+U9PUL/6BBgzRo0CDNnDlTXbp00e9//3ulp6fLz89PtbW113xc4eHh6tixo/bs2aP777//kmNftmyZTp065QoWH3/8sVuZsLAwVVZW6sSJE65A9Pe//92tTL9+/bRjxw7FxMTUe7x+fn6S1CBfi8bUvXt3BQYGKjc3V5MmTXLbFxcXp6VLl7p9LTdt2iRfX99vXf38platWikpKUlJSUnKyMhQ27Zt9f7772v06NF1fj9t2rRJAwcO1GOPPebatnv3bo+PraG+Vxsa92FpIn70ox/pq6++0rhx47Rt2zbt3r1b7777rlJTU1VbW6vrr79eN9xwg1577TXt2rVL77//vtLT0709bHyLb5vX4OBgPfzww3ryySf1/vvvq7CwUA899JAriNQlJiZGZ86c0YIFC7Rnzx4tW7ZMCxcubMSjapoee+wx7d+/Xz/+8Y9VXFysd955RxkZGUpPT5evr6+2bNmiuXPn6m9/+5v27dunnJwcHT58WHFxcZK+vrfFJ598oh07dujIkSMXrV5cjdmzZyszM1O//OUvtXPnTn366adasmSJsrKyJEnjx4+Xj4+P0tLS9Pnnn2vdunV66aWX3NpITExUUFCQpk+frt27d+vNN9/U0qVL3crMnDlTb7zxhmbPnq3PPvtMRUVFWrFihWbMmHHFY+3SpYt8fHy0du1aHT582LVC1NQEBATo6aef1lNPPaU33nhDu3fv1scff6zXX39d999/vwICAjRx4kQVFhbqgw8+0I9//GM98MADrtNB32bt2rX65S9/qb///e/65z//qTfeeENOp9MVeKKiorRlyxaVlpa6TvF3795df/vb3/Tuu+9q586devbZZ7Vt2zaPjy0qKkoffvihvvzySx05csTj+t5CYGkiOnbsqE2bNqm2tlZ33nmn4uPj9dOf/lRt27aVr6+vfH19tWLFCuXn56tXr1762c9+phdffNHbw8a3+LZ5laQXX3xRgwcP1siRI5WUlKTbb79dCQkJl2yzT58+ysrK0gsvvKBevXrp//7v/5SZmdlYh9RkderUSevWrdPWrVvVp08fPfroo3r44Yddv6xDQ0P14YcfasSIEerRo4dmzJihefPm6a677pIkpaWlqWfPnrr11lsVFhamTZs2XbOxTZo0Sb/5zW+0ZMkSxcfHa8iQIVq6dKnrVFRwcLD+8Ic/6NNPP9Utt9yiZ5555qLTjO3atdPy5cu1bt06xcfH66233tKsWbPcyiQnJ2vt2rV677339N3vflf9+/fXyy+/fNn7xFyoU6dOmj17tqZOnarw8HBNmTLlqo/fW5599lk9/vjjmjlzpuLi4jR27FgdOnRIQUFBevfdd/XVV1/pu9/9rsaMGaM77rhD//u//3vFbbdt21Y5OTn6t3/7N8XFxWnhwoV66623dPPNN0uSnnjiCTkcDt10000KCwvTvn379Mgjj2j06NEaO3asEhMTdfToUbfVliv13HPPqbS0VNHR0U3qHk4+prmdtAYAqLS0VF27dtX27du57T+aBVZYAACA9QgsANAA5s6dq+Dg4Dof504jAbhynBICgAbw1Vdf6auvvqpzX2BgoDp16tTIIwKaNgILAACwHqeEAACA9QgsAADAegQWAABgPQILAACwHoEFAABYj8ACAACsR2ABAADWI7AAAADr/T8C4M/P+e2XbAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# compare statistical imputation strategies for the horse colic dataset from numpy import mean\n",
+    "from numpy import std\n",
+    "from pandas import read_csv\n",
+    "from sklearn.ensemble import RandomForestClassifier \n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "from sklearn.model_selection import RepeatedStratifiedKFold \n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from matplotlib import pyplot \n",
+    "\n",
+    "# load dataset\n",
+    "horse_colic_data = horse_colic_data_copy\n",
+    "\n",
+    "# split into input and output elements\n",
+    "data = horse_colic_data.values\n",
+    "ix = [i for i in range(data.shape[1]) if i != 23] \n",
+    "X, y = data[:, ix], data[:, 23]\n",
+    "\n",
+    "# evaluate each strategy on the dataset \n",
+    "results = list()\n",
+    "strategies = ['mean', 'median', 'most_frequent', 'constant'] \n",
+    "\n",
+    "for s in strategies:\n",
+    "    # create the modeling pipeline\n",
+    "    pipeline = Pipeline(steps=[('i', SimpleImputer(strategy=s)), ('m', RandomForestClassifier())])\n",
+    "\n",
+    "    # evaluate the model\n",
+    "    cv = RepeatedStratifiedKFold(n_splits=10, n_repeats=3, random_state=1)\n",
+    "    scores = cross_val_score(pipeline, X, y, scoring='accuracy', cv=cv, n_jobs=-1) # store results\n",
+    "    results.append(scores)\n",
+    "    print('>%s %.3f (%.3f)' % (s, mean(scores), std(scores))) \n",
+    "\n",
+    "# plot model performance for comparison \n",
+    "pyplot.boxplot(results, tick_labels=strategies, showmeans=True) \n",
+    "pyplot.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef18f8e2-117c-4680-84b9-e3e23544f856",
+   "metadata": {},
+   "source": [
+    "#### SimpleImputer Transform When Making a Prediction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "1fc920aa-27b0-49b8-8ee4-95e504cc4f73",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted Class: 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# constant imputation strategy and prediction for the horse colic dataset from numpy import nan\n",
+    "from pandas import read_csv\n",
+    "from sklearn.ensemble import RandomForestClassifier \n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "\n",
+    "# load dataset\n",
+    "horse_colic_data = horse_colic_data_copy\n",
+    "\n",
+    "# split into input and output elements\n",
+    "data = horse_colic_data.values\n",
+    "ix = [i for i in range(data.shape[1]) if i != 23] \n",
+    "X, y = data[:, ix], data[:, 23]\n",
+    "\n",
+    "# create the modeling pipeline\n",
+    "pipeline = Pipeline(steps=[('i', SimpleImputer(strategy='constant')), ('m', RandomForestClassifier())])\n",
+    "\n",
+    "# fit the model \n",
+    "pipeline.fit(X, y) \n",
+    "\n",
+    "# define new data\n",
+    "row = [2, 1, 530101, 38.50, 66, 28, 3, 3, np.nan, 2, 5, 4, 4, np.nan, np.nan, np.nan, 3, 5, 45.00, 8.40, np.nan, np.nan, 2, 11300, 00000, 00000, 2]\n",
+    "\n",
+    "# make a prediction\n",
+    "yhat = pipeline.predict([row]) \n",
+    "\n",
+    "# summarize prediction\n",
+    "print('Predicted Class: %d'  % yhat[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffb2b404-8466-4d4b-81a0-7e83bb6d2d23",
+   "metadata": {},
+   "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6644402f-a0f6-45f5-843e-6557fcbd7720",
+   "id": "bec148c8-ffcf-43b3-9525-a38719b687ac",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Datasets may have missing values, and this can cause problems for many machine learning algorithms. As such, it is good practice to identify and replace missing values for each column in your input data prior to modeling your prediction task. This is called missing data imputation, or imputing for short. A popular approach for data imputation is to calculate a statistical value for each column (such as a mean) and replace all missing values for that column with the statistic. It is a popular approach because the statistic is easy to calculate using the training dataset and because it often results in good performance. In this tutorial, you will discover how to use statistical imputation strategies for missing data in machine learning. 

After completing this tutorial, you will know:
•	Missing values must be marked with NaN values and can be replaced with statistical measures to calculate the column of values.
•	**How to load a CSV file with missing values and mark the missing values with NaN values** and report the number and percentage of missing values for each column.
•	How to impute missing values with statistics as a data preparation method when evaluating models and when fitting a final model to make predictions on new data.