### PR TITLE
Encode categorical data ok

### DIFF
--- a/notebooks/.ipynb_checkpoints/Data_preparation-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/Data_preparation-checkpoint.ipynb
@@ -8122,7 +8122,9 @@
    "cell_type": "code",
    "execution_count": 130,
    "id": "a3b67bc0-6a73-4ce3-a996-72e47ac6c7bd",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -8210,6 +8212,474 @@
     "pyplot.boxplot(results, tick_labels=names, showmeans=True) \n",
     "pyplot.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca38088d-52dc-4e42-8a99-98055d5b58ff",
+   "metadata": {},
+   "source": [
+    "### How to Encode Categorical Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72d2bf94-b44b-4e66-bc1b-5f488efa590c",
+   "metadata": {},
+   "source": [
+    "#### Ordinal Encoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6b086c4e-4557-4d53-beb4-8adf451d296e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['red']\n",
+      " ['green']\n",
+      " ['blue']]\n",
+      "[[2.]\n",
+      " [1.]\n",
+      " [0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# example of a ordinal encoding \n",
+    "from numpy import asarray\n",
+    "from sklearn.preprocessing import OrdinalEncoder \n",
+    "\n",
+    "# define data\n",
+    "data = asarray([['red'], ['green'], ['blue']]) \n",
+    "print(data)\n",
+    "\n",
+    "# define ordinal encoding \n",
+    "encoder = OrdinalEncoder() \n",
+    "\n",
+    "# transform data\n",
+    "result = encoder.fit_transform(data) \n",
+    "\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ea01e67-6785-4939-94f1-e81323f202a5",
+   "metadata": {},
+   "source": [
+    "#### One Hot Encoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "4eb88889-374b-4ce7-ab89-b9f575fdd112",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['red']\n",
+      " ['green']\n",
+      " ['blue']]\n",
+      "[[0. 0. 1.]\n",
+      " [0. 1. 0.]\n",
+      " [1. 0. 0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# example of a one hot encoding \n",
+    "from numpy import asarray\n",
+    "from sklearn.preprocessing import OneHotEncoder \n",
+    "\n",
+    "# define data\n",
+    "data = asarray([['red'], ['green'], ['blue']])\n",
+    "print(data)\n",
+    "\n",
+    "# define one hot encoding\n",
+    "encoder = OneHotEncoder(sparse_output=False) \n",
+    "\n",
+    "# transform data\n",
+    "onehot = encoder.fit_transform(data) \n",
+    "\n",
+    "print(onehot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57c397e6-18b1-4caf-85d0-1d0551bc0624",
+   "metadata": {},
+   "source": [
+    "#### Dummy Variable Encoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5e1c70c0-c1ee-4e50-94c1-ba23816818da",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['red']\n",
+      " ['green']\n",
+      " ['blue']]\n",
+      "[[0. 1.]\n",
+      " [1. 0.]\n",
+      " [0. 0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# example of a dummy variable encoding \n",
+    "from numpy import asarray\n",
+    "from sklearn.preprocessing import OneHotEncoder \n",
+    "\n",
+    "# define data\n",
+    "data = asarray([['red'], ['green'], ['blue']]) \n",
+    "print(data)\n",
+    "\n",
+    "# define one hot encoding\n",
+    "encoder = OneHotEncoder(drop='first', sparse_output=False) \n",
+    "\n",
+    "# transform data\n",
+    "onehot = encoder.fit_transform(data) \n",
+    "\n",
+    "print(onehot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3855b24-72e2-4c68-a6e8-3739e09de9b2",
+   "metadata": {},
+   "source": [
+    "#### Breast Cancer Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "30cecf1e-1c4e-4fed-a12c-5e3acd1b83ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input (286, 9)\n",
+      "Output (286,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load and summarize the dataset \n",
+    "from pandas import read_csv\n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str) \n",
+    "\n",
+    "# summarize\n",
+    "print('Input', X.shape) \n",
+    "print('Output', y.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4e8b5a1-9c72-43a4-850e-4ef807b1a267",
+   "metadata": {},
+   "source": [
+    "#### OrdinalEncoder Transform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "1f768698-1d8c-41d6-bd1a-3da89ec513a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input (286, 9)\n",
+      "[[2. 2. 2. 0. 1. 2. 1. 2. 0.]\n",
+      " [3. 0. 2. 0. 0. 0. 1. 0. 0.]\n",
+      " [3. 0. 6. 0. 0. 1. 0. 1. 0.]\n",
+      " [2. 2. 6. 0. 1. 2. 1. 1. 1.]\n",
+      " [2. 2. 5. 4. 1. 1. 0. 4. 0.]]\n",
+      "Output (286,)\n",
+      "[1 0 1 0 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ordinal encode the breast cancer dataset \n",
+    "from pandas import read_csv\n",
+    "from sklearn.preprocessing import LabelEncoder \n",
+    "from sklearn.preprocessing import OrdinalEncoder \n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str)\n",
+    "\n",
+    "# ordinal encode input variables \n",
+    "ordinal_encoder = OrdinalEncoder()\n",
+    "X = ordinal_encoder.fit_transform(X) \n",
+    "\n",
+    "# ordinal encode target variable \n",
+    "label_encoder = LabelEncoder()\n",
+    "y = label_encoder.fit_transform(y) \n",
+    "\n",
+    "# summarize the transformed data \n",
+    "print('Input', X.shape) \n",
+    "print(X[:5, :])\n",
+    "\n",
+    "print('Output', y.shape) \n",
+    "print(y[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4955896-025a-46f4-965f-79624ca3c7ba",
+   "metadata": {},
+   "source": [
+    "We can then fit a logistic regression algorithm on the training dataset and evaluate it on the test dataset. The complete example is listed below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e979a2af-7a6f-418e-b07e-294b39502cb8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 75.79\n"
+     ]
+    }
+   ],
+   "source": [
+    "#evaluate logistic regression on the breast cancer dataset with an ordinal encoding \n",
+    "from pandas import read_csv\n",
+    "from sklearn.model_selection import train_test_split \n",
+    "from sklearn.linear_model import LogisticRegression \n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "from sklearn.preprocessing import OrdinalEncoder \n",
+    "from sklearn.metrics import accuracy_score\n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str)\n",
+    "\n",
+    "# split the dataset into train and test sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=1) \n",
+    "\n",
+    "# ordinal encode input variables\n",
+    "ordinal_encoder = OrdinalEncoder() \n",
+    "ordinal_encoder.fit(X_train)\n",
+    "X_train = ordinal_encoder.transform(X_train) \n",
+    "X_test = ordinal_encoder.transform(X_test)\n",
+    "\n",
+    "# ordinal encode target variable \n",
+    "label_encoder = LabelEncoder() \n",
+    "label_encoder.fit(y_train)\n",
+    "y_train = label_encoder.transform(y_train) \n",
+    "y_test = label_encoder.transform(y_test)\n",
+    "\n",
+    "# define the model\n",
+    "model = LogisticRegression() \n",
+    "\n",
+    "# fit on the training set\n",
+    "model.fit(X_train, y_train)\n",
+    "\n",
+    "# predict on test set\n",
+    "yhat = model.predict(X_test) \n",
+    "\n",
+    "# evaluate predictions\n",
+    "accuracy = accuracy_score(y_test, yhat) \n",
+    "print('Accuracy: %.2f' % (accuracy*100))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55677dfc-b9d7-4728-bf29-53788859a1bf",
+   "metadata": {},
+   "source": [
+    "#### OneHotEncoder Transform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "9f9062bd-0281-43e2-822f-286ef8dc6832",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input (286, 43)\n",
+      "[[0. 0. 1. 0. 0. 0. 0. 0. 1. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0.\n",
+      "  0. 0. 0. 0. 1. 0. 0. 0. 1. 0. 1. 0. 0. 1. 0. 0. 0. 1. 0.]\n",
+      " [0. 0. 0. 1. 0. 0. 1. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0.\n",
+      "  0. 0. 0. 1. 0. 0. 1. 0. 0. 0. 1. 1. 0. 0. 0. 0. 0. 1. 0.]\n",
+      " [0. 0. 0. 1. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 1. 0. 0. 0.\n",
+      "  0. 0. 0. 1. 0. 0. 0. 1. 0. 1. 0. 0. 1. 0. 0. 0. 0. 1. 0.]\n",
+      " [0. 0. 1. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 1. 0. 0. 0.\n",
+      "  0. 0. 0. 0. 1. 0. 0. 0. 1. 0. 1. 0. 1. 0. 0. 0. 0. 0. 1.]\n",
+      " [0. 0. 1. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "  1. 0. 0. 0. 1. 0. 0. 1. 0. 1. 0. 0. 0. 0. 0. 1. 0. 1. 0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# one-hot encode the breast cancer dataset \n",
+    "from pandas import read_csv\n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "from sklearn.preprocessing import OneHotEncoder \n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str)\n",
+    "\n",
+    "# one hot encode input variables \n",
+    "onehot_encoder = OneHotEncoder(sparse_output=False)\n",
+    "X = onehot_encoder.fit_transform(X) \n",
+    "\n",
+    "# ordinal encode target variable \n",
+    "label_encoder = LabelEncoder()\n",
+    "y = label_encoder.fit_transform(y) \n",
+    "\n",
+    "# summarize the transformed data \n",
+    "print('Input', X.shape) \n",
+    "print(X[:5, :])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc1c5744-2c34-4911-9491-d41a35f504ef",
+   "metadata": {},
+   "source": [
+    "Next, let’s evaluate machine learning on this dataset with this encoding as we did in the previous section. The encoding is fit on the training set then applied to both train and test sets as before."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ba28c6b5-1bd5-40b9-af02-1ebd0968c36d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 70.53\n"
+     ]
+    }
+   ],
+   "source": [
+    "# evaluate logistic regression on the breast cancer dataset with a one-hot encoding \n",
+    "from pandas import read_csv\n",
+    "from sklearn.model_selection import train_test_split \n",
+    "from sklearn.linear_model import LogisticRegression \n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "from sklearn.preprocessing import OneHotEncoder\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str)\n",
+    "\n",
+    "# split the dataset into train and test sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=1) \n",
+    "\n",
+    "# one-hot encode input variables\n",
+    "onehot_encoder = OneHotEncoder() \n",
+    "onehot_encoder.fit(X_train)\n",
+    "X_train = onehot_encoder.transform(X_train) \n",
+    "X_test = onehot_encoder.transform(X_test)\n",
+    "\n",
+    "# ordinal encode target variable \n",
+    "label_encoder = LabelEncoder() \n",
+    "label_encoder.fit(y_train)\n",
+    "y_train = label_encoder.transform(y_train) \n",
+    "y_test = label_encoder.transform(y_test)\n",
+    "\n",
+    "# define the model\n",
+    "model = LogisticRegression() \n",
+    "\n",
+    "# fit on the training set \n",
+    "model.fit(X_train,  y_train) \n",
+    "\n",
+    "# predict on test set\n",
+    "yhat = model.predict(X_test) \n",
+    "\n",
+    "# evaluate predictions\n",
+    "accuracy = accuracy_score(y_test, yhat) \n",
+    "print('Accuracy: %.2f' % (accuracy*100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9b7e8c2-ebfa-4b2a-8793-dcdb5e3bb747",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08ff4881-1270-4ddf-896e-97bb95a84575",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/Data_preparation.ipynb
+++ b/notebooks/Data_preparation.ipynb
@@ -8122,7 +8122,9 @@
    "cell_type": "code",
    "execution_count": 130,
    "id": "a3b67bc0-6a73-4ce3-a996-72e47ac6c7bd",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -8210,6 +8212,474 @@
     "pyplot.boxplot(results, tick_labels=names, showmeans=True) \n",
     "pyplot.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca38088d-52dc-4e42-8a99-98055d5b58ff",
+   "metadata": {},
+   "source": [
+    "### How to Encode Categorical Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72d2bf94-b44b-4e66-bc1b-5f488efa590c",
+   "metadata": {},
+   "source": [
+    "#### Ordinal Encoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6b086c4e-4557-4d53-beb4-8adf451d296e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['red']\n",
+      " ['green']\n",
+      " ['blue']]\n",
+      "[[2.]\n",
+      " [1.]\n",
+      " [0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# example of a ordinal encoding \n",
+    "from numpy import asarray\n",
+    "from sklearn.preprocessing import OrdinalEncoder \n",
+    "\n",
+    "# define data\n",
+    "data = asarray([['red'], ['green'], ['blue']]) \n",
+    "print(data)\n",
+    "\n",
+    "# define ordinal encoding \n",
+    "encoder = OrdinalEncoder() \n",
+    "\n",
+    "# transform data\n",
+    "result = encoder.fit_transform(data) \n",
+    "\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ea01e67-6785-4939-94f1-e81323f202a5",
+   "metadata": {},
+   "source": [
+    "#### One Hot Encoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "4eb88889-374b-4ce7-ab89-b9f575fdd112",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['red']\n",
+      " ['green']\n",
+      " ['blue']]\n",
+      "[[0. 0. 1.]\n",
+      " [0. 1. 0.]\n",
+      " [1. 0. 0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# example of a one hot encoding \n",
+    "from numpy import asarray\n",
+    "from sklearn.preprocessing import OneHotEncoder \n",
+    "\n",
+    "# define data\n",
+    "data = asarray([['red'], ['green'], ['blue']])\n",
+    "print(data)\n",
+    "\n",
+    "# define one hot encoding\n",
+    "encoder = OneHotEncoder(sparse_output=False) \n",
+    "\n",
+    "# transform data\n",
+    "onehot = encoder.fit_transform(data) \n",
+    "\n",
+    "print(onehot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57c397e6-18b1-4caf-85d0-1d0551bc0624",
+   "metadata": {},
+   "source": [
+    "#### Dummy Variable Encoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5e1c70c0-c1ee-4e50-94c1-ba23816818da",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['red']\n",
+      " ['green']\n",
+      " ['blue']]\n",
+      "[[0. 1.]\n",
+      " [1. 0.]\n",
+      " [0. 0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# example of a dummy variable encoding \n",
+    "from numpy import asarray\n",
+    "from sklearn.preprocessing import OneHotEncoder \n",
+    "\n",
+    "# define data\n",
+    "data = asarray([['red'], ['green'], ['blue']]) \n",
+    "print(data)\n",
+    "\n",
+    "# define one hot encoding\n",
+    "encoder = OneHotEncoder(drop='first', sparse_output=False) \n",
+    "\n",
+    "# transform data\n",
+    "onehot = encoder.fit_transform(data) \n",
+    "\n",
+    "print(onehot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3855b24-72e2-4c68-a6e8-3739e09de9b2",
+   "metadata": {},
+   "source": [
+    "#### Breast Cancer Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "30cecf1e-1c4e-4fed-a12c-5e3acd1b83ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input (286, 9)\n",
+      "Output (286,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load and summarize the dataset \n",
+    "from pandas import read_csv\n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str) \n",
+    "\n",
+    "# summarize\n",
+    "print('Input', X.shape) \n",
+    "print('Output', y.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4e8b5a1-9c72-43a4-850e-4ef807b1a267",
+   "metadata": {},
+   "source": [
+    "#### OrdinalEncoder Transform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "1f768698-1d8c-41d6-bd1a-3da89ec513a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input (286, 9)\n",
+      "[[2. 2. 2. 0. 1. 2. 1. 2. 0.]\n",
+      " [3. 0. 2. 0. 0. 0. 1. 0. 0.]\n",
+      " [3. 0. 6. 0. 0. 1. 0. 1. 0.]\n",
+      " [2. 2. 6. 0. 1. 2. 1. 1. 1.]\n",
+      " [2. 2. 5. 4. 1. 1. 0. 4. 0.]]\n",
+      "Output (286,)\n",
+      "[1 0 1 0 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ordinal encode the breast cancer dataset \n",
+    "from pandas import read_csv\n",
+    "from sklearn.preprocessing import LabelEncoder \n",
+    "from sklearn.preprocessing import OrdinalEncoder \n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str)\n",
+    "\n",
+    "# ordinal encode input variables \n",
+    "ordinal_encoder = OrdinalEncoder()\n",
+    "X = ordinal_encoder.fit_transform(X) \n",
+    "\n",
+    "# ordinal encode target variable \n",
+    "label_encoder = LabelEncoder()\n",
+    "y = label_encoder.fit_transform(y) \n",
+    "\n",
+    "# summarize the transformed data \n",
+    "print('Input', X.shape) \n",
+    "print(X[:5, :])\n",
+    "\n",
+    "print('Output', y.shape) \n",
+    "print(y[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4955896-025a-46f4-965f-79624ca3c7ba",
+   "metadata": {},
+   "source": [
+    "We can then fit a logistic regression algorithm on the training dataset and evaluate it on the test dataset. The complete example is listed below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e979a2af-7a6f-418e-b07e-294b39502cb8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 75.79\n"
+     ]
+    }
+   ],
+   "source": [
+    "#evaluate logistic regression on the breast cancer dataset with an ordinal encoding \n",
+    "from pandas import read_csv\n",
+    "from sklearn.model_selection import train_test_split \n",
+    "from sklearn.linear_model import LogisticRegression \n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "from sklearn.preprocessing import OrdinalEncoder \n",
+    "from sklearn.metrics import accuracy_score\n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str)\n",
+    "\n",
+    "# split the dataset into train and test sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=1) \n",
+    "\n",
+    "# ordinal encode input variables\n",
+    "ordinal_encoder = OrdinalEncoder() \n",
+    "ordinal_encoder.fit(X_train)\n",
+    "X_train = ordinal_encoder.transform(X_train) \n",
+    "X_test = ordinal_encoder.transform(X_test)\n",
+    "\n",
+    "# ordinal encode target variable \n",
+    "label_encoder = LabelEncoder() \n",
+    "label_encoder.fit(y_train)\n",
+    "y_train = label_encoder.transform(y_train) \n",
+    "y_test = label_encoder.transform(y_test)\n",
+    "\n",
+    "# define the model\n",
+    "model = LogisticRegression() \n",
+    "\n",
+    "# fit on the training set\n",
+    "model.fit(X_train, y_train)\n",
+    "\n",
+    "# predict on test set\n",
+    "yhat = model.predict(X_test) \n",
+    "\n",
+    "# evaluate predictions\n",
+    "accuracy = accuracy_score(y_test, yhat) \n",
+    "print('Accuracy: %.2f' % (accuracy*100))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55677dfc-b9d7-4728-bf29-53788859a1bf",
+   "metadata": {},
+   "source": [
+    "#### OneHotEncoder Transform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "9f9062bd-0281-43e2-822f-286ef8dc6832",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input (286, 43)\n",
+      "[[0. 0. 1. 0. 0. 0. 0. 0. 1. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0.\n",
+      "  0. 0. 0. 0. 1. 0. 0. 0. 1. 0. 1. 0. 0. 1. 0. 0. 0. 1. 0.]\n",
+      " [0. 0. 0. 1. 0. 0. 1. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0.\n",
+      "  0. 0. 0. 1. 0. 0. 1. 0. 0. 0. 1. 1. 0. 0. 0. 0. 0. 1. 0.]\n",
+      " [0. 0. 0. 1. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 1. 0. 0. 0.\n",
+      "  0. 0. 0. 1. 0. 0. 0. 1. 0. 1. 0. 0. 1. 0. 0. 0. 0. 1. 0.]\n",
+      " [0. 0. 1. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 1. 0. 0. 0.\n",
+      "  0. 0. 0. 0. 1. 0. 0. 0. 1. 0. 1. 0. 1. 0. 0. 0. 0. 0. 1.]\n",
+      " [0. 0. 1. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "  1. 0. 0. 0. 1. 0. 0. 1. 0. 1. 0. 0. 0. 0. 0. 1. 0. 1. 0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# one-hot encode the breast cancer dataset \n",
+    "from pandas import read_csv\n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "from sklearn.preprocessing import OneHotEncoder \n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str)\n",
+    "\n",
+    "# one hot encode input variables \n",
+    "onehot_encoder = OneHotEncoder(sparse_output=False)\n",
+    "X = onehot_encoder.fit_transform(X) \n",
+    "\n",
+    "# ordinal encode target variable \n",
+    "label_encoder = LabelEncoder()\n",
+    "y = label_encoder.fit_transform(y) \n",
+    "\n",
+    "# summarize the transformed data \n",
+    "print('Input', X.shape) \n",
+    "print(X[:5, :])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc1c5744-2c34-4911-9491-d41a35f504ef",
+   "metadata": {},
+   "source": [
+    "Next, let’s evaluate machine learning on this dataset with this encoding as we did in the previous section. The encoding is fit on the training set then applied to both train and test sets as before."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ba28c6b5-1bd5-40b9-af02-1ebd0968c36d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 70.53\n"
+     ]
+    }
+   ],
+   "source": [
+    "# evaluate logistic regression on the breast cancer dataset with a one-hot encoding \n",
+    "from pandas import read_csv\n",
+    "from sklearn.model_selection import train_test_split \n",
+    "from sklearn.linear_model import LogisticRegression \n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "from sklearn.preprocessing import OneHotEncoder\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "\n",
+    "# load the dataset\n",
+    "path_breast_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/breast-cancer.csv\"\n",
+    "dataset = read_csv(path_breast_data, header=None) \n",
+    "\n",
+    "# retrieve the array of data\n",
+    "data = dataset.values\n",
+    "\n",
+    "# separate into input and output columns\n",
+    "X = data[:, :-1].astype(str)\n",
+    "y = data[:, -1].astype(str)\n",
+    "\n",
+    "# split the dataset into train and test sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=1) \n",
+    "\n",
+    "# one-hot encode input variables\n",
+    "onehot_encoder = OneHotEncoder() \n",
+    "onehot_encoder.fit(X_train)\n",
+    "X_train = onehot_encoder.transform(X_train) \n",
+    "X_test = onehot_encoder.transform(X_test)\n",
+    "\n",
+    "# ordinal encode target variable \n",
+    "label_encoder = LabelEncoder() \n",
+    "label_encoder.fit(y_train)\n",
+    "y_train = label_encoder.transform(y_train) \n",
+    "y_test = label_encoder.transform(y_test)\n",
+    "\n",
+    "# define the model\n",
+    "model = LogisticRegression() \n",
+    "\n",
+    "# fit on the training set \n",
+    "model.fit(X_train,  y_train) \n",
+    "\n",
+    "# predict on test set\n",
+    "yhat = model.predict(X_test) \n",
+    "\n",
+    "# evaluate predictions\n",
+    "accuracy = accuracy_score(y_test, yhat) \n",
+    "print('Accuracy: %.2f' % (accuracy*100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9b7e8c2-ebfa-4b2a-8793-dcdb5e3bb747",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08ff4881-1270-4ddf-896e-97bb95a84575",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
# How to Encode Categorical Data
Machine learning models require all input and output variables to be numeric. 

This means that if your data contains categorical data, you must encode it to numbers before you can fit and evaluate a model. 

The two most popular techniques are an **Ordinal encoding** and a **One Hot encoding**.

In this tutorial, you will discover how to use encoding schemes for categorical machine learning data.

After completing this tutorial, you will know:
•	Encoding is a required pre-processing step when working with categorical data for machine learning algorithms.
•	How to use ordinal encoding for categorical variables that have a natural rank ordering.
•	How to use one hot encoding for categorical variables that do not have a natural rank ordering.