### PR TITLE
Transform numerical and categorical data ok

### DIFF
--- a/notebooks/.ipynb_checkpoints/Data_preparation-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/Data_preparation-checkpoint.ipynb
@@ -12595,12 +12595,223 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a91a7146-3fe0-4417-b0c7-ac8acdb0ae9e",
+   "cell_type": "markdown",
+   "id": "365a0d48-992d-4b17-b0c1-8d1a463995d0",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Advanced Transforms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff1e124a-e1e2-47c2-b076-17e3f6cc2c72",
+   "metadata": {},
+   "source": [
+    "### How to Transform Numerical and Categorical Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc31bf60-a738-45be-95b7-4e36936645ca",
+   "metadata": {},
+   "source": [
+    "🔧 **Why Data Transformation Is Needed**\n",
+    "- Essential for preparing raw data before model training.\n",
+    "- Ensures machine learning algorithms can understand and learn from the data structure.\n",
+    "- Different types of data (numerical vs. categorical) require different preprocessing steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97f0e591-9de7-4549-aa9e-dca03d5a2246",
+   "metadata": {},
+   "source": [
+    "⚠️ **Challenges with Mixed Data Types**\n",
+    "- Mixed-type datasets need tailored preprocessing per column type.\n",
+    "- Manual separation and transformation of columns is inefficient and error-prone.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b0ee7a2-0e05-4486-bbdb-699c7568eef9",
+   "metadata": {},
+   "source": [
+    "🧰 **Solution: ColumnTransformer (scikit-learn)**\n",
+    "- Enables selective transformation of specific columns.\n",
+    "- Automatically applies different transforms to numerical vs. categorical data.\n",
+    "- Avoids manual column management and recombination."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "227a2e67-f5d3-4520-8a08-381879519dc1",
+   "metadata": {},
+   "source": [
+    "🔨 **How to Use ColumnTransformer**\n",
+    "- Define a list of transformers: Each as a tuple: (\"name\", transform_object, columns)\n",
+    "- Example usage:<br>\n",
+    "o\tApply **OneHotEncoder** to **categorical columns** (e.g., columns 0 & 1).<br>\n",
+    "o\tApply **SimpleImputer(median)** to **numerical columns**.\n",
+    "- **Remainder options**:<br>\n",
+    "o\t**drop (default)**: drops unspecified columns.<br>\n",
+    "o\t**passthrough**: passes through untouched columns."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "561b2656-ccce-44a8-8ca7-4a1ad41d9b12",
+   "metadata": {},
+   "source": [
+    "🔁 **Integrating ColumnTransformer in a Pipeline**\n",
+    "- Combine ColumnTransformer with model in a Pipeline.\n",
+    "- Ensures consistent preprocessing for: **Training**, **Cross-validation**, **Future predictions**\n",
+    "- Enables automation and reproducibility."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15e00164-ed5d-4d4b-a5df-ad65504fd0f8",
+   "metadata": {},
+   "source": [
+    "🧠 **Key Takeaways for Practice**\n",
+    "- Mixed-type preprocessing is streamlined with ColumnTransformer.\n",
+    "- Always evaluate with cross-validation for reliable metrics.\n",
+    "- Modular and reusable pipelines increase efficiency and model accuracy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb402927-e8f0-4137-a743-571b0668f7d7",
+   "metadata": {},
+   "source": [
+    "#### Data Preparation for the Abalone Regression Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2134bdde-4348-465d-aacb-bf5cd6416a83",
+   "metadata": {},
+   "source": [
+    "The abalone dataset is a standard machine learning problem that involves predicting the age of an abalone given measurements of an abalone. The dataset has 4,177 examples, 8 input variables, and the target variable is an integer. A naive model can achieve a mean absolute error (MAE) of about 2.363 (std 0.092) by predicting the mean value, evaluated via 10-fold cross-validation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f0cea79-0fd2-4b70-ba7b-00dff3147207",
+   "metadata": {},
+   "source": [
+    "We can see that the first column is categorical and the remainder of the columns are numerical. We may want to one hot encode the first column and normalize the remaining numerical columns, and this can be achieved using the ColumnTransformer. We can model this as a regression predictive modeling problem with a support vector machine model (SVR). First, we need to load the dataset. We can load the dataset directly from the file using the read csv() Pandas function, then split the data into two data frames: one for input and one for the output. The complete example of loading the dataset is listed below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a09e7a7b-1e2c-49a8-b449-47ef72a1cfd0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(4177, 8) (4177,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load the dataset\n",
+    "from pandas import read_csv \n",
+    "\n",
+    "# load dataset\n",
+    "path_abalone_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/abalone.csv  \"\n",
+    "dataframe = read_csv(path_abalone_data, header=None) \n",
+    "\n",
+    "# split into inputs and outputs\n",
+    "last_ix = len(dataframe.columns) - 1\n",
+    "X, y = dataframe.drop(last_ix, axis=1), dataframe[last_ix] \n",
+    "\n",
+    "print(X.shape, y.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22b9aee0-73e2-4a78-b1e5-11ecdd750646",
+   "metadata": {},
+   "source": [
+    "Next, we can use the **select dtypes()** function to select the column indexes that match different data types. <br>We are interested in a list of columns that are numerical columns marked as float64 or int64 in Pandas, and a list of categorical columns, marked as object or bool type in Pandas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0a8f44e0-8317-4f13-b651-50ad65742b65",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(4177, 8) (4177,)\n",
+      "MAE: 1.465 (0.047)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# example of using the ColumnTransformer for the Abalone dataset \n",
+    "from numpy import mean\n",
+    "from numpy import std\n",
+    "from numpy import absolute \n",
+    "from pandas import read_csv\n",
+    "from sklearn.model_selection import cross_val_score \n",
+    "from sklearn.model_selection import KFold\n",
+    "from sklearn.compose import ColumnTransformer \n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OneHotEncoder \n",
+    "from sklearn.preprocessing import MinMaxScaler \n",
+    "from sklearn.svm import SVR\n",
+    "\n",
+    "# load dataset\n",
+    "path_abalone_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/abalone.csv  \"\n",
+    "dataframe = read_csv(path_abalone_data, header=None) \n",
+    "\n",
+    "# split into inputs and outputs\n",
+    "last_ix = len(dataframe.columns) - 1\n",
+    "X, y = dataframe.drop(last_ix, axis=1), dataframe[last_ix] \n",
+    "print(X.shape, y.shape)\n",
+    "\n",
+    "# determine categorical and numerical features\n",
+    "numerical_ix = X.select_dtypes(include=['int64', 'float64']).columns \n",
+    "categorical_ix = X.select_dtypes(include=['object', 'bool']).columns \n",
+    "\n",
+    "# define the data preparation for the columns\n",
+    "t = [('cat', OneHotEncoder(), categorical_ix), ('num', MinMaxScaler(), numerical_ix)] \n",
+    "col_transform = ColumnTransformer(transformers=t)\n",
+    "\n",
+    "# define the model\n",
+    "model  =  SVR(kernel='rbf',gamma='scale',C=100)\n",
+    "\n",
+    "# define the data preparation and modeling pipeline\n",
+    "pipeline = Pipeline(steps=[('prep',col_transform), ('m', model)]) \n",
+    "\n",
+    "# define the model cross-validation configuration\n",
+    "cv = KFold(n_splits=10, shuffle=True, random_state=1)\n",
+    "\n",
+    "# evaluate the pipeline using cross validation and calculate MAE\n",
+    "scores = cross_val_score(pipeline, X, y, scoring='neg_mean_absolute_error', cv=cv, n_jobs=-1)\n",
+    "\n",
+    "# convert MAE scores to positive values \n",
+    "scores = absolute(scores)\n",
+    "\n",
+    "# summarize the model performance\n",
+    "print('MAE: %.3f (%.3f)' % (mean(scores), std(scores)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc5c03f-de96-4705-a40d-2379b03fd9d9",
+   "metadata": {},
+   "source": [
+    "You now have a template for using the ColumnTransformer on a dataset with mixed data types that you can use and adapt for your own projects in the future."
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/Data_preparation.ipynb
+++ b/notebooks/Data_preparation.ipynb
@@ -12595,12 +12595,223 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a91a7146-3fe0-4417-b0c7-ac8acdb0ae9e",
+   "cell_type": "markdown",
+   "id": "365a0d48-992d-4b17-b0c1-8d1a463995d0",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Advanced Transforms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff1e124a-e1e2-47c2-b076-17e3f6cc2c72",
+   "metadata": {},
+   "source": [
+    "### How to Transform Numerical and Categorical Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc31bf60-a738-45be-95b7-4e36936645ca",
+   "metadata": {},
+   "source": [
+    "🔧 **Why Data Transformation Is Needed**\n",
+    "- Essential for preparing raw data before model training.\n",
+    "- Ensures machine learning algorithms can understand and learn from the data structure.\n",
+    "- Different types of data (numerical vs. categorical) require different preprocessing steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97f0e591-9de7-4549-aa9e-dca03d5a2246",
+   "metadata": {},
+   "source": [
+    "⚠️ **Challenges with Mixed Data Types**\n",
+    "- Mixed-type datasets need tailored preprocessing per column type.\n",
+    "- Manual separation and transformation of columns is inefficient and error-prone.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b0ee7a2-0e05-4486-bbdb-699c7568eef9",
+   "metadata": {},
+   "source": [
+    "🧰 **Solution: ColumnTransformer (scikit-learn)**\n",
+    "- Enables selective transformation of specific columns.\n",
+    "- Automatically applies different transforms to numerical vs. categorical data.\n",
+    "- Avoids manual column management and recombination."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "227a2e67-f5d3-4520-8a08-381879519dc1",
+   "metadata": {},
+   "source": [
+    "🔨 **How to Use ColumnTransformer**\n",
+    "- Define a list of transformers: Each as a tuple: (\"name\", transform_object, columns)\n",
+    "- Example usage:<br>\n",
+    "o\tApply **OneHotEncoder** to **categorical columns** (e.g., columns 0 & 1).<br>\n",
+    "o\tApply **SimpleImputer(median)** to **numerical columns**.\n",
+    "- **Remainder options**:<br>\n",
+    "o\t**drop (default)**: drops unspecified columns.<br>\n",
+    "o\t**passthrough**: passes through untouched columns."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "561b2656-ccce-44a8-8ca7-4a1ad41d9b12",
+   "metadata": {},
+   "source": [
+    "🔁 **Integrating ColumnTransformer in a Pipeline**\n",
+    "- Combine ColumnTransformer with model in a Pipeline.\n",
+    "- Ensures consistent preprocessing for: **Training**, **Cross-validation**, **Future predictions**\n",
+    "- Enables automation and reproducibility."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15e00164-ed5d-4d4b-a5df-ad65504fd0f8",
+   "metadata": {},
+   "source": [
+    "🧠 **Key Takeaways for Practice**\n",
+    "- Mixed-type preprocessing is streamlined with ColumnTransformer.\n",
+    "- Always evaluate with cross-validation for reliable metrics.\n",
+    "- Modular and reusable pipelines increase efficiency and model accuracy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb402927-e8f0-4137-a743-571b0668f7d7",
+   "metadata": {},
+   "source": [
+    "#### Data Preparation for the Abalone Regression Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2134bdde-4348-465d-aacb-bf5cd6416a83",
+   "metadata": {},
+   "source": [
+    "The abalone dataset is a standard machine learning problem that involves predicting the age of an abalone given measurements of an abalone. The dataset has 4,177 examples, 8 input variables, and the target variable is an integer. A naive model can achieve a mean absolute error (MAE) of about 2.363 (std 0.092) by predicting the mean value, evaluated via 10-fold cross-validation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f0cea79-0fd2-4b70-ba7b-00dff3147207",
+   "metadata": {},
+   "source": [
+    "We can see that the first column is categorical and the remainder of the columns are numerical. We may want to one hot encode the first column and normalize the remaining numerical columns, and this can be achieved using the ColumnTransformer. We can model this as a regression predictive modeling problem with a support vector machine model (SVR). First, we need to load the dataset. We can load the dataset directly from the file using the read csv() Pandas function, then split the data into two data frames: one for input and one for the output. The complete example of loading the dataset is listed below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a09e7a7b-1e2c-49a8-b449-47ef72a1cfd0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(4177, 8) (4177,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load the dataset\n",
+    "from pandas import read_csv \n",
+    "\n",
+    "# load dataset\n",
+    "path_abalone_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/abalone.csv  \"\n",
+    "dataframe = read_csv(path_abalone_data, header=None) \n",
+    "\n",
+    "# split into inputs and outputs\n",
+    "last_ix = len(dataframe.columns) - 1\n",
+    "X, y = dataframe.drop(last_ix, axis=1), dataframe[last_ix] \n",
+    "\n",
+    "print(X.shape, y.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22b9aee0-73e2-4a78-b1e5-11ecdd750646",
+   "metadata": {},
+   "source": [
+    "Next, we can use the **select dtypes()** function to select the column indexes that match different data types. <br>We are interested in a list of columns that are numerical columns marked as float64 or int64 in Pandas, and a list of categorical columns, marked as object or bool type in Pandas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0a8f44e0-8317-4f13-b651-50ad65742b65",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(4177, 8) (4177,)\n",
+      "MAE: 1.465 (0.047)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# example of using the ColumnTransformer for the Abalone dataset \n",
+    "from numpy import mean\n",
+    "from numpy import std\n",
+    "from numpy import absolute \n",
+    "from pandas import read_csv\n",
+    "from sklearn.model_selection import cross_val_score \n",
+    "from sklearn.model_selection import KFold\n",
+    "from sklearn.compose import ColumnTransformer \n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OneHotEncoder \n",
+    "from sklearn.preprocessing import MinMaxScaler \n",
+    "from sklearn.svm import SVR\n",
+    "\n",
+    "# load dataset\n",
+    "path_abalone_data = \"https://raw.githubusercontent.com/jbrownlee/Datasets/master/abalone.csv  \"\n",
+    "dataframe = read_csv(path_abalone_data, header=None) \n",
+    "\n",
+    "# split into inputs and outputs\n",
+    "last_ix = len(dataframe.columns) - 1\n",
+    "X, y = dataframe.drop(last_ix, axis=1), dataframe[last_ix] \n",
+    "print(X.shape, y.shape)\n",
+    "\n",
+    "# determine categorical and numerical features\n",
+    "numerical_ix = X.select_dtypes(include=['int64', 'float64']).columns \n",
+    "categorical_ix = X.select_dtypes(include=['object', 'bool']).columns \n",
+    "\n",
+    "# define the data preparation for the columns\n",
+    "t = [('cat', OneHotEncoder(), categorical_ix), ('num', MinMaxScaler(), numerical_ix)] \n",
+    "col_transform = ColumnTransformer(transformers=t)\n",
+    "\n",
+    "# define the model\n",
+    "model  =  SVR(kernel='rbf',gamma='scale',C=100)\n",
+    "\n",
+    "# define the data preparation and modeling pipeline\n",
+    "pipeline = Pipeline(steps=[('prep',col_transform), ('m', model)]) \n",
+    "\n",
+    "# define the model cross-validation configuration\n",
+    "cv = KFold(n_splits=10, shuffle=True, random_state=1)\n",
+    "\n",
+    "# evaluate the pipeline using cross validation and calculate MAE\n",
+    "scores = cross_val_score(pipeline, X, y, scoring='neg_mean_absolute_error', cv=cv, n_jobs=-1)\n",
+    "\n",
+    "# convert MAE scores to positive values \n",
+    "scores = absolute(scores)\n",
+    "\n",
+    "# summarize the model performance\n",
+    "print('MAE: %.3f (%.3f)' % (mean(scores), std(scores)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc5c03f-de96-4705-a40d-2379b03fd9d9",
+   "metadata": {},
+   "source": [
+    "You now have a template for using the ColumnTransformer on a dataset with mixed data types that you can use and adapt for your own projects in the future."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
# How to Transform Numerical and Categorical Data
You must prepare your raw data using data transforms prior to fitting a machine learning model. 

This is required to ensure that you best expose the structure of your predictive modeling problem to the learning algorithms. 

Applying data transforms like scaling or encoding categorical variables is straightforward when all input variables are the same type. It can be challenging when you have a dataset with mixed types and you want to selectively apply data transforms to some, but not all, input features.

Thankfully, the scikit-learn Python machine learning library provides the **ColumnTransformer** that allows you to selectively apply data transforms to different columns in your dataset. 

In this tutorial, you will discover how to use the **ColumnTransformer** to selectively apply data transforms to columns in a dataset with mixed data types. 

After completing this tutorial, you will know:
•	The challenge of using data transformations with datasets that have mixed data types.
•	How to define, fit, and use the **ColumnTransformer** to **selectively apply data transforms to columns**.
•	How to work through a real dataset with mixed data types and use the **ColumnTransformer** to apply different transforms to categorical and numerical data columns.
